### PR TITLE
docs(readme): make README user-facing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,53 @@
 <p align="center">
-  <img src="assets/banner-v4-lowres.png" alt="Evil Farm Owner" width="900">
+  <img src="assets/banner-v4-lowres.png" alt="Evil Farm Owner banner" width="820">
+</p>
+
+<h1 align="center">
+  <img src="assets/icon-v2.png" alt="Evil Farm Owner icon" width="52" align="center">
+  Evil Farm Owner v0.1.0
+</h1>
+
+<p align="center">
+  <strong>邪恶农场主</strong><br>
+  Hire farmhands, pay wages, and let someone else handle the repetitive farm work.
 </p>
 
 <p align="center">
-  <img src="assets/icon-v2.png" alt="Evil Farm Owner icon" width="128">
-</p>
-
-<h1 align="center">Evil Farm Owner v0.1.0</h1>
-
-<p align="center">
-  <strong>中文名：邪恶农场主</strong><br>
-  Hire farmhands, pay wages, and let someone else do the repetitive work.
-</p>
-
-<p align="center">
-  <a href="#中文说明">中文</a> ·
+  <a href="#中文">中文</a> ·
   <a href="#english">English</a> ·
-  <a href="#roadmap">Roadmap</a>
+  <a href="#plan-list">Plan List</a> ·
+  <a href="#idea-list">Idea List</a> ·
+  <a href="#bug-list">Bug List</a>
 </p>
 
 ---
 
 <details open>
-<summary id="中文说明"><strong>中文说明</strong></summary>
+<summary id="中文"><strong>中文</strong></summary>
 
-## 项目定位
+## 这个 Mod 是做什么的？
 
-`邪恶农场主` 是一个面向《星露谷物语》的 SMAPI Mod。它的核心设定是：玩家支付工资，雇佣农工完成重复农活，包括浇水、收获、清理、施肥和播种。
+`邪恶农场主` 让你在《星露谷物语》中花钱雇佣农工，把重复农活交出去。当前版本已经可以在农场内一键派工，帮助你浇水、收获、清理杂物，并可选择施肥和播种。
 
-当前版本是 `0.1.0`，属于早期可玩原型。重点是先跑通“雇佣 -> 派工 -> 执行任务 -> 支付工资”的基础链路，后续再加入可见 NPC、真实寻路、仓库整理、箱子分类、机器补料和联机同步。
+这不是一个完整的经营系统，当前版本更像“雇佣农工”的第一版可玩原型。后续会逐步加入雇佣菜单、可见 NPC、仓库整理和更完整的自动化流程。
 
-## 当前功能
+## 当前能做什么？
 
-- 按 `H` 在农场派工一次。
+- 按 `H` 派工一次。
 - 自动浇水。
 - 自动收获成熟作物。
 - 自动清理树枝、石头、杂草等农场杂物。
-- 可选：从背包消耗肥料并给空地施肥。
-- 可选：从背包消耗种子并播种。
-- 工资系统：每次有效派工默认扣除 `500g`。
-- 中文和英文文本。
-- SMAPI 控制台命令，方便测试和调试。
+- 可选：从背包拿肥料给空地施肥。
+- 可选：从背包拿种子播种。
+- 有工资消耗，默认每次有效派工扣除 `500g`。
+- 支持中文和英文文本。
 
-## 使用方式
+## 怎么用？
 
-安装后进入游戏，站在农场内按 `H`，农工会在配置范围内执行一次已开启的任务。
+1. 安装 SMAPI。
+2. 把 Mod 文件夹放进 `Stardew Valley/Mods`。
+3. 通过 SMAPI 启动游戏。
+4. 进入农场，按 `H` 派工。
 
 也可以在 SMAPI 控制台输入：
 
@@ -52,13 +55,13 @@
 efo_work
 ```
 
-查看当前状态：
+查看当前配置：
 
 ```text
 efo_status
 ```
 
-切换单项任务：
+开关单项工作：
 
 ```text
 efo_toggle water
@@ -68,7 +71,7 @@ efo_toggle fertilize
 efo_toggle plant
 ```
 
-## 配置
+## 配置文件
 
 配置文件位于：
 
@@ -76,47 +79,49 @@ efo_toggle plant
 Mods/EvilFarmOwner/config.json
 ```
 
-| 配置项 | 作用 | 默认值 |
+| 配置项 | 说明 | 默认值 |
 | --- | --- | --- |
 | `OpenMenuKey` | 派工快捷键 | `H` |
 | `WorkRadius` | 工作扫描范围 | `64` |
 | `DailyWage` | 每次有效派工费用 | `500` |
-| `MaxTilesPerJob` | 单次最多处理的地块/对象数 | `250` |
+| `MaxTilesPerJob` | 单次最多处理数量 | `250` |
 | `WaterCrops` | 自动浇水 | `true` |
 | `HarvestCrops` | 自动收获 | `true` |
 | `ClearDebris` | 自动清理杂物 | `true` |
 | `FertilizeEmptyDirt` | 自动施肥 | `false` |
 | `PlantSeedsFromInventory` | 自动播种 | `false` |
-| `DepositHarvestToNearestChest` | 收获物转入附近箱子，待开发 | `false` |
+| `DepositHarvestToNearestChest` | 收获物放入附近箱子，待开发 | `false` |
 
 </details>
 
 <details>
 <summary id="english"><strong>English</strong></summary>
 
-## What is this?
+## What does this mod do?
 
-`Evil Farm Owner` is a Stardew Valley SMAPI mod about hiring farmhands to handle repetitive farm work. Pay a wage, send workers out, and let them water crops, harvest mature crops, clear debris, fertilize soil, and plant seeds.
+`Evil Farm Owner` lets you hire farmhands in Stardew Valley so repetitive farm work is no longer all on you. The current version can run one work pass on the farm to water crops, harvest mature crops, clear debris, and optionally fertilize or plant seeds.
 
-Version `0.1.0` is an early playable prototype. The goal is to establish the core loop first: hire, assign work, execute tasks, and charge wages. Future versions can build on this foundation with visible NPC workers, pathfinding, warehouse logic, chest sorting, machine refilling, and multiplayer sync.
+This is not a full management system yet. Version `0.1.0` is the first playable prototype for the hired-worker loop. Future versions will add a proper hiring menu, visible NPC workers, warehouse sorting, and richer automation.
 
 ## Current Features
 
-- Press `H` on the farm to run one work pass.
+- Press `H` to send farmhands out for one work pass.
 - Water crops.
 - Harvest mature crops.
 - Clear farm debris like twigs, stones, and weeds.
-- Optional: fertilize empty dirt using fertilizer from the player inventory.
-- Optional: plant seeds from the player inventory.
-- Wage system, defaulting to `500g` per successful work pass.
+- Optional: fertilize empty dirt using fertilizer from your inventory.
+- Optional: plant seeds from your inventory.
+- Wage cost, defaulting to `500g` per successful work pass.
 - Chinese and English text.
-- SMAPI console commands for testing and debugging.
 
-## Usage
+## How to Use
 
-After installing the mod, enter the farm and press `H`.
+1. Install SMAPI.
+2. Put the mod folder into `Stardew Valley/Mods`.
+3. Launch the game through SMAPI.
+4. Enter the farm and press `H`.
 
-You can also run:
+You can also run this in the SMAPI console:
 
 ```text
 efo_work
@@ -151,7 +156,7 @@ Mods/EvilFarmOwner/config.json
 | `OpenMenuKey` | Work hotkey | `H` |
 | `WorkRadius` | Work scan radius | `64` |
 | `DailyWage` | Wage per successful work pass | `500` |
-| `MaxTilesPerJob` | Max tiles or objects handled per pass | `250` |
+| `MaxTilesPerJob` | Max handled tiles or objects per pass | `250` |
 | `WaterCrops` | Water crops | `true` |
 | `HarvestCrops` | Harvest mature crops | `true` |
 | `ClearDebris` | Clear debris | `true` |
@@ -163,55 +168,35 @@ Mods/EvilFarmOwner/config.json
 
 ---
 
-## Roadmap
+## Plan List
 
-- In-game hiring menu.
-- Named workers or temporary worker NPCs.
-- Visible pathfinding and work animations.
-- Warehouse and storage anchor system.
-- Chest sorting and item classification.
+- Add an in-game hiring menu instead of relying on only a hotkey and console commands.
+- Add visible hired workers or temporary NPC workers.
+- Add worker movement, pathfinding, and work animations.
+- Add a warehouse or office anchor for hiring, seed storage, fertilizer storage, and harvest output.
+- Add host-authoritative multiplayer support.
+
+## Idea List
+
+- Chest sorting by item type, quality, season, or custom labels.
 - Machine refilling and product collection.
-- Animal care tasks.
-- Host-authoritative multiplayer support.
+- Animal care jobs such as petting, feeding checks, and product pickup.
+- Tiered worker contracts with different wages, speeds, and job limits.
+- Evil capitalist flavor text, worker complaints, and event-style messages.
 
-## Design Notes
+## Bug List
 
-The mod is designed around a task system, so future work types can be added without rewriting the hiring flow.
+- Multiplayer support is not complete; the host should run the work pass for now.
+- Visible NPC workers are not implemented yet; tasks execute instantly.
+- Harvest output currently follows the game's default harvest behavior instead of a custom warehouse route.
+- `DepositHarvestToNearestChest` is listed in config but not implemented yet.
+- Planting uses the first available seed stack in the player inventory and does not yet provide a crop selection UI.
 
-```text
-Hire System
-├── Worker Contract
-├── Task Scheduler
-├── Farm Scan
-├── Work Tasks
-│   ├── Water
-│   ├── Harvest
-│   ├── Clear Debris
-│   ├── Fertilize
-│   ├── Plant
-│   └── Sort Chests
-└── Storage / Warehouse
-```
-
-## Development
-
-Requirements:
+## Compatibility
 
 - Stardew Valley 1.6+
 - SMAPI 4.0+
-- .NET 6 SDK
-
-Build:
-
-```bash
-dotnet build -c Release
-```
-
-The project uses `Pathoschild.Stardew.ModBuildConfig`, which can generate a ready-to-install mod package after a release build.
-
-## Multiplayer
-
-The current prototype should be run by the host player. Proper multiplayer support is planned around host-side game-state mutation and client-side work requests.
+- No required content packs.
 
 ## License
 


### PR DESCRIPTION
## Summary
Improve the README so it reads as a player-facing mod page instead of a developer note.

## Changes
- Place the logo inline with the main README title.
- Reframe the Chinese and English sections around player usage.
- Add Plan List, Idea List, and Bug List sections.
- Keep the existing bilingual README structure.
- Keep the low-resolution banner as the top visual element.

## Validation
- Reviewed README structure locally.
- Confirmed the banner and icon paths resolve in the repository.
- Confirmed the PR branch contains only README-facing documentation changes on top of main.

## Authorship
- Commit author: Aveouter <78571076+Aveouter@users.noreply.github.com>
- Commit committer: Aveouter <78571076+Aveouter@users.noreply.github.com>