### PR TITLE
fix(multiplayer): show host-only work restriction

### DIFF
--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -44,6 +44,7 @@ public sealed class ModEntry : Mod
         if (!Context.IsMainPlayer)
         {
             this.Monitor.Log("Farmhand automation should run on the host player in multiplayer.", LogLevel.Info);
+            Game1.addHUDMessage(new HUDMessage(this.Helper.Translation.Get("hud.host-only"), HUDMessage.error_type));
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ efo_toggle fertilize
 efo_toggle plant
 ```
 
+In multiplayer, only the host player can start a work pass. Farmhand players
+who try to hire workers will receive a message explaining this limitation.
+
 ### Configuration
 
 The config file is created at:
@@ -137,6 +140,9 @@ efo_toggle clear
 efo_toggle fertilize
 efo_toggle plant
 ```
+
+联机模式目前只能由主机玩家发起工作。农场帮手玩家尝试雇佣农工时，
+会收到说明此限制的提示，且不会改变农场状态或扣除工资。
 
 ### 配置文件
 

--- a/i18n/default.json
+++ b/i18n/default.json
@@ -1,5 +1,6 @@
 {
   "hud.ready": "Evil Farm Owner is ready. Press {{key}} or use 'efo_work'.",
+  "hud.host-only": "Only the host player can hire farmhands in multiplayer for now.",
   "hud.no-farm": "Farmhands only work on the farm.",
   "hud.no-money": "Not enough gold to hire farmhands. Need {{gold}}g.",
   "hud.done": "Farmhands finished: watered {{watered}}, harvested {{harvested}}, cleared {{cleared}}, fertilized {{fertilized}}, planted {{planted}}.",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -1,5 +1,6 @@
 {
   "hud.ready": "邪恶农场主已就绪。按 {{key}} 或使用命令 efo_work 派工。",
+  "hud.host-only": "联机模式目前只能由主机玩家雇佣农工。",
   "hud.no-farm": "雇佣农工目前只在农场工作。",
   "hud.no-money": "金币不足，雇佣农工需要 {{gold}}g。",
   "hud.done": "农工完成工作：浇水 {{watered}} 格，收获 {{harvested}} 格，清理 {{cleared}} 个，施肥 {{fertilized}} 格，播种 {{planted}} 格。",


### PR DESCRIPTION
## Summary / 变更概述

Prevent farmhand clients from silently attempting state-changing work passes and show a localized host-only message.

## Linked Issue

Closes #5

## 修改动机

The host-authoritative guard already returned on clients, but only wrote a SMAPI log. Players received no visible explanation, so the existing behavior did not satisfy the prototype stabilization acceptance criteria.

## 主要改动

- Show a HUD error when a farmhand client attempts to hire workers.
- Add English and Chinese host-only translations.
- Document the current multiplayer restriction in both README languages.

## Change Type

- [ ] `feat`: user-facing feature
- [x] `fix`: bug fix
- [ ] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [ ] `test`: test or validation work

## Validation / 实验与验证

- [x] Built locally with `dotnet build -c Release -p:EnableModDeploy=false -p:EnableModZip=false`
- [ ] Launched with SMAPI
- [ ] Tested in a save file
- [x] Multiplayer impact considered
- [x] Documentation updated
- Result: 0 warnings and 0 errors. Game deployment and packaging were disabled.

## 对 Benchmark / Baseline 的影响

No datasets, evaluation protocols, metrics, baselines, or reproducibility results are affected.

## Multiplayer Impact

Farm state remains host-authoritative. Clients now receive feedback and still cannot execute or pay for work passes.

## 风险与限制

The change has not been validated through SMAPI or a multiplayer save because this development pass is restricted to source-level production checks. Keep this PR in draft until gameplay validation is completed.