### PR TITLE
fix(config): validate wage and work limits

### DIFF
--- a/ConfigValidator.cs
+++ b/ConfigValidator.cs
@@ -1,0 +1,48 @@
+namespace EvilFarmOwner;
+
+internal static class ConfigValidator
+{
+    internal const int MinWorkRadius = 1;
+    internal const int MaxWorkRadius = 256;
+    internal const int MinDailyWage = 0;
+    internal const int MaxDailyWage = 100_000_000;
+    internal const int MinTilesPerJob = 1;
+    internal const int MaxTilesPerJob = 10_000;
+
+    public static IReadOnlyList<string> Normalize(ModConfig config)
+    {
+        List<string> warnings = new();
+
+        int workRadius = Math.Clamp(config.WorkRadius, MinWorkRadius, MaxWorkRadius);
+        if (workRadius != config.WorkRadius)
+        {
+            warnings.Add($"WorkRadius must be between {MinWorkRadius} and {MaxWorkRadius}; using {workRadius}.");
+            config.WorkRadius = workRadius;
+        }
+
+        int dailyWage = Math.Clamp(config.DailyWage, MinDailyWage, MaxDailyWage);
+        if (dailyWage != config.DailyWage)
+        {
+            warnings.Add($"DailyWage must be between {MinDailyWage} and {MaxDailyWage}; using {dailyWage}.");
+            config.DailyWage = dailyWage;
+        }
+
+        int maxTilesPerJob = Math.Clamp(config.MaxTilesPerJob, MinTilesPerJob, MaxTilesPerJob);
+        if (maxTilesPerJob != config.MaxTilesPerJob)
+        {
+            warnings.Add($"MaxTilesPerJob must be between {MinTilesPerJob} and {MaxTilesPerJob}; using {maxTilesPerJob}.");
+            config.MaxTilesPerJob = maxTilesPerJob;
+        }
+
+        return warnings;
+    }
+
+    public static bool HasEnabledJobs(ModConfig config)
+    {
+        return config.WaterCrops
+            || config.HarvestCrops
+            || config.ClearDebris
+            || config.FertilizeEmptyDirt
+            || config.PlantSeedsFromInventory;
+    }
+}

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -19,6 +19,12 @@ public sealed class ModEntry : Mod
     public override void Entry(IModHelper helper)
     {
         this.Config = helper.ReadConfig<ModConfig>();
+        IReadOnlyList<string> configWarnings = ConfigValidator.Normalize(this.Config);
+        bool shouldWriteConfig = configWarnings.Count > 0;
+
+        foreach (string warning in configWarnings)
+            this.Monitor.Log($"Invalid config: {warning}", LogLevel.Warn);
+
         this.HasKnownHotkeyConflict = this.Config.OpenMenuKey == SButton.H
             && helper.ModRegistry.IsLoaded("Annosz.UiInfoSuite2");
         this.WorkerRoster = new WorkerRosterService(this.Monitor);
@@ -29,9 +35,12 @@ public sealed class ModEntry : Mod
         if (this.Config.ClearDebris)
         {
             this.Config.ClearDebris = false;
-            helper.WriteConfig(this.Config);
+            shouldWriteConfig = true;
             this.Monitor.Log(helper.Translation.Get("cmd.clear-disabled"), LogLevel.Warn);
         }
+
+        if (shouldWriteConfig)
+            helper.WriteConfig(this.Config);
 
         helper.Events.GameLoop.SaveLoaded += this.OnSaveLoaded;
         helper.Events.Input.ButtonPressed += this.OnButtonPressed;
@@ -103,6 +112,12 @@ public sealed class ModEntry : Mod
         if (Game1.currentLocation is not Farm farm)
         {
             Game1.addHUDMessage(new HUDMessage(this.Helper.Translation.Get("hud.no-farm"), HUDMessage.error_type));
+            return;
+        }
+
+        if (!ConfigValidator.HasEnabledJobs(this.Config))
+        {
+            Game1.addHUDMessage(new HUDMessage(this.Helper.Translation.Get("hud.no-tasks"), HUDMessage.error_type));
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ Mods/EvilFarmOwner/config.json
 | Key | Description | Default |
 | --- | --- | --- |
 | `OpenMenuKey` | Hotkey for the read-only worker roster | `K` |
-| `WorkRadius` | Work scan radius around the player | `64` |
-| `DailyWage` | Legacy `efo_work` prototype charge; the named contract preview uses its itemized hourly model | `500` |
-| `MaxTilesPerJob` | Maximum handled tiles or objects per work pass | `250` |
+| `WorkRadius` | Work scan radius around the player (`1`–`256`) | `64` |
+| `DailyWage` | Legacy `efo_work` prototype charge (`0`–`100000000`); the named contract preview uses its itemized hourly model | `500` |
+| `MaxTilesPerJob` | Maximum handled tiles or objects per work pass (`1`–`10000`) | `250` |
 | `WaterCrops` | Enable crop watering | `true` |
 | `HarvestCrops` | Enable crop harvesting | `true` |
 | `ClearDebris` | Debris cleanup compatibility setting; forced off for safety | `false` |
@@ -171,9 +171,9 @@ Mods/EvilFarmOwner/config.json
 | 配置项 | 说明 | 默认值 |
 | --- | --- | --- |
 | `OpenMenuKey` | 打开只读工人名单的快捷键 | `K` |
-| `WorkRadius` | 以玩家为中心的工作扫描范围 | `64` |
-| `DailyWage` | 旧版 `efo_work` 原型扣款；具名合同预览使用逐项时薪模型 | `500` |
-| `MaxTilesPerJob` | 单次最多处理的地块或对象数量 | `250` |
+| `WorkRadius` | 以玩家为中心的工作扫描范围（`1`–`256`） | `64` |
+| `DailyWage` | 旧版 `efo_work` 原型扣款（`0`–`100000000`）；具名合同预览使用逐项时薪模型 | `500` |
+| `MaxTilesPerJob` | 单次最多处理的地块或对象数量（`1`–`10000`） | `250` |
 | `WaterCrops` | 开启自动浇水 | `true` |
 | `HarvestCrops` | 开启自动收获 | `true` |
 | `ClearDebris` | 杂物清理兼容配置；当前会被安全地强制关闭 | `false` |

--- a/i18n/default.json
+++ b/i18n/default.json
@@ -2,6 +2,7 @@
   "hud.ready": "Evil Farm Owner is ready. Press {{key}} to view worker candidates.",
   "hud.hotkey-conflict": "Evil Farm Owner's H key conflicts with UI Info Suite 2. Set OpenMenuKey to K or use 'efo_roster'.",
   "hud.no-farm": "Farmhands only work on the farm.",
+  "hud.no-tasks": "No farmhand jobs are enabled.",
   "hud.no-money": "Not enough gold to hire farmhands. Need {{gold}}g.",
   "hud.done": "Farmhands finished: watered {{watered}}, harvested {{harvested}}, cleared {{cleared}}, fertilized {{fertilized}}, planted {{planted}}.",
   "hud.empty": "Farmhands found no available work.",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -2,6 +2,7 @@
   "hud.ready": "邪恶农场主已就绪。按 {{key}} 查看工人候选名单。",
   "hud.hotkey-conflict": "邪恶农场主的 H 键与 UI Info Suite 2 冲突。请将 OpenMenuKey 改为 K，或使用命令 efo_roster。",
   "hud.no-farm": "雇佣农工目前只在农场工作。",
+  "hud.no-tasks": "当前没有开启任何农工任务。",
   "hud.no-money": "金币不足，雇佣农工需要 {{gold}}g。",
   "hud.done": "农工完成工作：浇水 {{watered}} 格，收获 {{harvested}} 格，清理 {{cleared}} 个，施肥 {{fertilized}} 格，播种 {{planted}} 格。",
   "hud.empty": "农工没有找到可执行的工作。",


### PR DESCRIPTION
## Summary / 变更概述

Normalize unsafe user-configured values before farm work starts and skip work requests when every job is disabled.

## Linked Issue

Closes #12

## 修改动机

A negative DailyWage could make wage deduction add money. Extreme WorkRadius and MaxTilesPerJob values were also accepted without limits, and no-job requests still scanned the farm.

## 主要改动

- Add centralized config normalization with documented safety bounds.
- Log and persist corrected config values during mod startup.
- Return before scanning or charging when no farmhand jobs are enabled.
- Add English and Chinese no-job messages.
- Document accepted numeric ranges in the README.

## Change Type

- [ ] `feat`: user-facing feature
- [x] `fix`: bug fix
- [ ] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [ ] `test`: test or validation work

## Validation / 实验与验证

- [x] Built locally with `dotnet build -c Release -p:EnableModDeploy=false -p:EnableModZip=false`
- [x] Launched with SMAPI
- [x] Tested in a save file
- [x] Multiplayer impact considered
- [x] Documentation updated
- Result: 0 warnings and 0 errors. The source-linked boundary and task-toggle matrix passed, and SMAPI/save validation passed on 2026-08-24.

## 对 Benchmark / Baseline 的影响

No datasets, evaluation protocols, metrics, baselines, or reproducibility results are affected.

## Multiplayer Impact

Config normalization runs at mod startup. Farm-work authority and synchronization behavior are unchanged.

## 风险与限制

The safety bounds may need adjustment for unusually large custom farm maps. Validation used a reversible test config, which was restored exactly after SMAPI stopped.
