### PR TITLE
fix(farm-work): disable unsafe debris cleanup

### DIFF
--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -10,7 +10,7 @@ internal sealed class ModConfig
     public int MaxTilesPerJob { get; set; } = 250;
     public bool WaterCrops { get; set; } = true;
     public bool HarvestCrops { get; set; } = true;
-    public bool ClearDebris { get; set; } = true;
+    public bool ClearDebris { get; set; } = false;
     public bool FertilizeEmptyDirt { get; set; } = false;
     public bool PlantSeedsFromInventory { get; set; } = false;
     public bool DepositHarvestToNearestChest { get; set; } = false;

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -18,6 +18,13 @@ public sealed class ModEntry : Mod
     {
         this.Config = helper.ReadConfig<ModConfig>();
 
+        if (this.Config.ClearDebris)
+        {
+            this.Config.ClearDebris = false;
+            helper.WriteConfig(this.Config);
+            this.Monitor.Log(helper.Translation.Get("cmd.clear-disabled"), LogLevel.Warn);
+        }
+
         helper.Events.GameLoop.SaveLoaded += this.OnSaveLoaded;
         helper.Events.Input.ButtonPressed += this.OnButtonPressed;
 
@@ -74,9 +81,6 @@ public sealed class ModEntry : Mod
 
             if (this.Config.HarvestCrops)
                 didWork |= this.TryHarvest(farm, tile, report);
-
-            if (this.Config.ClearDebris)
-                didWork |= this.TryClearDebris(farm, tile, report);
 
             if (this.Config.FertilizeEmptyDirt)
                 didWork |= this.TryFertilize(farm, tile, report);
@@ -148,25 +152,6 @@ public sealed class ModEntry : Mod
             return false;
 
         report.Harvested++;
-        return true;
-    }
-
-    private bool TryClearDebris(GameLocation location, Vector2 tile, WorkReport report)
-    {
-        if (!location.objects.TryGetValue(tile, out SObject obj))
-            return false;
-
-        string name = obj.Name.ToLowerInvariant();
-        bool isDebris = name.Contains("stone", StringComparison.Ordinal)
-            || name.Contains("twig", StringComparison.Ordinal)
-            || name.Contains("weed", StringComparison.Ordinal)
-            || obj.Category == SObject.junkCategory;
-
-        if (!isDebris)
-            return false;
-
-        location.objects.Remove(tile);
-        report.Cleared++;
         return true;
     }
 
@@ -243,7 +228,8 @@ public sealed class ModEntry : Mod
                 this.Config.HarvestCrops = !this.Config.HarvestCrops;
                 break;
             case "clear":
-                this.Config.ClearDebris = !this.Config.ClearDebris;
+                this.Config.ClearDebris = false;
+                this.Monitor.Log(this.Helper.Translation.Get("cmd.clear-disabled"), LogLevel.Warn);
                 break;
             case "fertilize":
                 this.Config.FertilizeEmptyDirt = !this.Config.FertilizeEmptyDirt;

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  Pay farmhands to handle watering, harvesting, debris cleanup, fertilizing, and planting.
+  Pay farmhands to handle watering, harvesting, fertilizing, and planting.
 </p>
 
 <p align="center">
@@ -36,7 +36,7 @@ Press one key, pay a wage, and let hired farmhands run a work pass on your farm.
 - Hire farmhands with the `H` key.
 - Water crops.
 - Harvest mature crops.
-- Clear farm debris such as twigs, stones, and weeds.
+- Debris cleanup is temporarily disabled while resource-safe delivery is implemented.
 - Optionally fertilize empty dirt using fertilizer from your inventory.
 - Optionally plant seeds from your inventory.
 - Charge a wage after successful work, defaulting to `500g`.
@@ -69,6 +69,8 @@ efo_toggle fertilize
 efo_toggle plant
 ```
 
+`efo_toggle clear` is retained for config compatibility, but reports that debris cleanup is temporarily disabled.
+
 ### Configuration
 
 The config file is created at:
@@ -85,7 +87,7 @@ Mods/EvilFarmOwner/config.json
 | `MaxTilesPerJob` | Maximum handled tiles or objects per work pass | `250` |
 | `WaterCrops` | Enable crop watering | `true` |
 | `HarvestCrops` | Enable crop harvesting | `true` |
-| `ClearDebris` | Enable debris cleanup | `true` |
+| `ClearDebris` | Debris cleanup compatibility setting; forced off for safety | `false` |
 | `FertilizeEmptyDirt` | Enable fertilizing from inventory | `false` |
 | `PlantSeedsFromInventory` | Enable planting from inventory | `false` |
 | `DepositHarvestToNearestChest` | Planned chest deposit behavior | `false` |
@@ -105,7 +107,7 @@ Mods/EvilFarmOwner/config.json
 - 按 `H` 雇佣农工执行一次工作。
 - 自动浇水。
 - 自动收获成熟作物。
-- 自动清理树枝、石头、杂草等农场杂物。
+- 杂物清理暂时停用，等待实现不会丢失资源的交付逻辑。
 - 可选：从背包拿肥料给空地施肥。
 - 可选：从背包拿种子播种。
 - 有工资系统，默认每次有效工作扣除 `500g`。
@@ -138,6 +140,8 @@ efo_toggle fertilize
 efo_toggle plant
 ```
 
+为了兼容已有配置，仍保留 `efo_toggle clear`；执行时会提示杂物清理暂时停用。
+
 ### 配置文件
 
 配置文件位置：
@@ -154,7 +158,7 @@ Mods/EvilFarmOwner/config.json
 | `MaxTilesPerJob` | 单次最多处理的地块或对象数量 | `250` |
 | `WaterCrops` | 开启自动浇水 | `true` |
 | `HarvestCrops` | 开启自动收获 | `true` |
-| `ClearDebris` | 开启杂物清理 | `true` |
+| `ClearDebris` | 杂物清理兼容配置；当前会被安全地强制关闭 | `false` |
 | `FertilizeEmptyDirt` | 开启背包施肥 | `false` |
 | `PlantSeedsFromInventory` | 开启背包播种 | `false` |
 | `DepositHarvestToNearestChest` | 计划中的箱子入库功能 | `false` |
@@ -183,6 +187,7 @@ Mods/EvilFarmOwner/config.json
 
 - Multiplayer support is not complete; the host should run work passes for now.
 - Workers are not visible yet; tasks execute instantly.
+- Debris cleanup is disabled until normal drops and a safe delivery destination are implemented.
 - Harvest output uses the game's default behavior for now.
 - `DepositHarvestToNearestChest` is listed in config but not implemented yet.
 - Planting currently uses the first available seed stack in the player inventory.

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "MaxTilesPerJob": 250,
   "WaterCrops": true,
   "HarvestCrops": true,
-  "ClearDebris": true,
+  "ClearDebris": false,
   "FertilizeEmptyDirt": false,
   "PlantSeedsFromInventory": false,
   "DepositHarvestToNearestChest": false

--- a/i18n/default.json
+++ b/i18n/default.json
@@ -6,6 +6,7 @@
   "hud.empty": "Farmhands found no available work.",
   "cmd.work": "Hire farmhands to do one round of enabled work.",
   "cmd.status": "Show Hired Farmhands status.",
-  "cmd.toggle": "Toggle one task: water, harvest, clear, fertilize, plant.",
+  "cmd.toggle": "Toggle one task: water, harvest, fertilize, or plant. The clear task is temporarily disabled.",
+  "cmd.clear-disabled": "Debris cleanup is temporarily disabled to prevent resource loss.",
   "cmd.status.line": "Hired Farmhands: water={{water}}, harvest={{harvest}}, clear={{clear}}, fertilize={{fertilize}}, plant={{plant}}, radius={{radius}}, wage={{wage}}g."
 }

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -6,6 +6,7 @@
   "hud.empty": "农工没有找到可执行的工作。",
   "cmd.work": "雇佣农工执行一次已开启的农场工作。",
   "cmd.status": "显示雇佣农工状态。",
-  "cmd.toggle": "切换任务开关：water、harvest、clear、fertilize、plant。",
+  "cmd.toggle": "切换任务开关：water、harvest、fertilize、plant；clear 任务暂时停用。",
+  "cmd.clear-disabled": "为防止资源丢失，杂物清理功能暂时停用。",
   "cmd.status.line": "雇佣农工：浇水={{water}}，收获={{harvest}}，清理={{clear}}，施肥={{fertilize}}，播种={{plant}}，范围={{radius}}，工资={{wage}}g。"
 }


### PR DESCRIPTION
## Summary

Disable the current debris cleanup path because it directly removes farm objects without preserving their normal drops. Existing `ClearDebris: true` configs are migrated to `false`, the console command cannot re-enable the task, and the direct-removal handler is no longer reachable or present.

This is a temporary safety containment. The complete resource-preserving cleanup design and implementation remains tracked in #20.

## Linked Issue

Closes #22
Refs #20

## Change Type

- [ ] `feat`: user-facing feature
- [x] `fix`: bug fix
- [ ] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [ ] `test`: test or validation work

## Validation

- [x] Built locally with `dotnet build -c Release`
- [x] Launched with SMAPI
- [x] Tested in a save file
- [x] Multiplayer impact considered
- [x] Documentation updated if user-facing behavior changed

## Notes

Release build completed with 0 warnings and 0 errors. Gameplay validation passed in a disposable/restorable save; the deployed Mod and saves were restored afterward. The work executor remains host-authoritative; this change removes a mutation path and adds no client-side behavior.

