### PR TITLE
feat(report): add latest contract report command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Added `efo_overflow` to retrieve already harvested cargo preserved after a storage-triggered stop.
 - Added host-authoritative multiplayer contract requests, bounded request replay protection, phase/cargo/transfer snapshots, reconnect synchronization, and host-only visual action messages.
 - Persisted the bounded processed-request ledger and latest per-player results so host restarts rebind prior transactions to the new network session without repeating work or charges.
+- Added read-only `efo_report` output for the current player's latest authoritative contract result, including grouped cargo, destinations, and billing.
 - Rejected internally inconsistent multiplayer recovery results with duplicate transfer IDs, unbalanced item destinations, impossible hours, or contradictory success reasons.
 - Required a nonce-correlated authoritative sync-state handshake before a farmhand binds a new host session or resends a pending request, so delayed responses or sync states from the prior host session cannot capture reconnect state; clean protocol-3 and protocol-4 recovery ledgers are fully validated before being rebound to protocol 5.
 - Bound wage reservation and refund to the requesting farmer instead of the host's local player.
@@ -35,7 +36,7 @@
 - Added a separate persistent emergency cargo quarantine, idempotent transfer markers, a size-bounded host recovery record, and `efo_quarantine` retrieval so failed overflow and ground-drop operations cannot release the only owned item instances.
 - Required day end, ordinary saving, and initial save creation to verify cargo ownership and force any transient remainder into the private team quarantine before contract settlement.
 - Added a compile-gated, non-distributable storage fault-injection harness for live overflow, drop, quarantine, recovery-record, and terminal-write acceptance tests; the normal Release verifier rejects any DLL which exposes its command.
-- Expanded the deterministic logic harness to 45 wage, availability, routing, storage, quarantine recovery, acceptance-control, protocol serialization, authorization, ordering, reconnect, stale-message, and replay tests.
+- Expanded the deterministic logic harness to 49 wage, availability, routing, storage, reporting, quarantine recovery, acceptance-control, protocol serialization, authorization, ordering, reconnect, stale-message, and replay tests.
 - Removed the legacy instant `efo_work`, task toggles, player-centered scan settings, and bundled user config from the production release surface.
 - Corrected manifest ownership, release description, and GitHub update metadata.
 - Added English and Chinese UI, configuration, multiplayer, failure, storage, and settlement text.

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -60,6 +60,7 @@ public sealed class ModEntry : Mod
         helper.ConsoleCommands.Add("efo_overflow", helper.Translation.Get("cmd.overflow"), (_, _) => this.OpenHarvestOverflow());
         helper.ConsoleCommands.Add("efo_quarantine", helper.Translation.Get("cmd.quarantine"), (_, _) => this.OpenHarvestQuarantine());
         helper.ConsoleCommands.Add("efo_netstatus", helper.Translation.Get("cmd.netstatus"), (_, _) => this.ShowNetworkStatus());
+        helper.ConsoleCommands.Add("efo_report", helper.Translation.Get("cmd.report"), (_, _) => this.ShowLastWorkReport());
 #if EFO_ACCEPTANCE_FAULTS
         helper.ConsoleCommands.Add(
             "efo_acceptance_faults",
@@ -424,6 +425,63 @@ public sealed class ModEntry : Mod
         this.Monitor.Log(
             this.MultiplayerContracts?.GetDiagnosticStatus() ?? "EFO network coordinator is unavailable.",
             LogLevel.Info);
+    }
+
+    private void ShowLastWorkReport()
+    {
+        if (!Context.IsWorldReady)
+        {
+            this.Monitor.Log(this.Helper.Translation.Get("cmd.roster-world-not-ready"), LogLevel.Info);
+            return;
+        }
+
+        if (this.MultiplayerContracts?.TryGetRecentResult(
+                Game1.player.UniqueMultiplayerID,
+                out ContractResultMessage? result) != true
+            || result is null)
+        {
+            this.Monitor.Log(this.Helper.Translation.Get("report.none"), LogLevel.Info);
+            return;
+        }
+
+        string task = this.Helper.Translation.Get(result.Task == NamedFarmTask.Watering
+            ? "contract.task.watering"
+            : "contract.task.harvesting");
+        string status = result.Succeeded
+            ? this.Helper.Translation.Get("report.status.completed")
+            : this.Helper.Translation.Get("report.status.stopped", new
+            {
+                reason = this.Helper.Translation.Get(result.ReasonKey)
+            });
+        string items = NamedContractReportFormatter.FormatItems(
+            result.ProducedItems,
+            this.Helper.Translation.Get("report.items.none"));
+
+        this.Monitor.Log(this.Helper.Translation.Get("report.header", new
+        {
+            worker = result.WorkerName,
+            task,
+            status
+        }), LogLevel.Info);
+        this.Monitor.Log(this.Helper.Translation.Get("report.work", new
+        {
+            completed = result.CompletedWork,
+            items
+        }), LogLevel.Info);
+        this.Monitor.Log(this.Helper.Translation.Get("report.destinations", new
+        {
+            player = result.PlayerItems,
+            chest = result.ChestItems,
+            overflow = result.OverflowItems,
+            quarantine = result.QuarantinedItems,
+            dropped = result.DroppedItems
+        }), LogLevel.Info);
+        this.Monitor.Log(this.Helper.Translation.Get("report.billing", new
+        {
+            hours = result.BillableHours,
+            paid = result.ChargedGold,
+            refunded = result.RefundedGold
+        }), LogLevel.Info);
     }
 
 }

--- a/MultiplayerContractCoordinator.cs
+++ b/MultiplayerContractCoordinator.cs
@@ -58,6 +58,11 @@ internal sealed class MultiplayerContractCoordinator
     public bool HasObservedActiveContract => this.CurrentHostSnapshot is not null
         || this.RemoteActiveSnapshot is not null;
 
+    public bool TryGetRecentResult(long requestingPlayerId, out ContractResultMessage? result)
+    {
+        return this.RecentResults.TryGetValue(requestingPlayerId, out result);
+    }
+
     public string GetDiagnosticStatus()
     {
         string role = Context.IsMainPlayer ? "host" : "farmhand";
@@ -646,6 +651,7 @@ internal sealed class MultiplayerContractCoordinator
             return;
 
         this.RemoteStateVersions.Commit(result.StateVersion);
+        this.RecentResults[result.RequestingPlayerId] = result;
 
         if (this.RemoteActiveSnapshot?.ContractId == result.ContractId)
             this.RemoteActiveSnapshot = null;

--- a/NamedContractReportFormatter.cs
+++ b/NamedContractReportFormatter.cs
@@ -1,0 +1,31 @@
+namespace EvilFarmOwner;
+
+internal sealed record NamedContractReportItem(string DisplayName, int Quality, int Stack);
+
+internal static class NamedContractReportFormatter
+{
+    public static IReadOnlyList<NamedContractReportItem> SummarizeItems(
+        IEnumerable<ContractCargoSnapshotMessage> items)
+    {
+        return items
+            .GroupBy(item => new { item.DisplayName, item.Quality })
+            .Select(group => new NamedContractReportItem(
+                group.Key.DisplayName,
+                group.Key.Quality,
+                group.Sum(item => item.Stack)))
+            .OrderBy(item => item.DisplayName, StringComparer.Ordinal)
+            .ThenBy(item => item.Quality)
+            .ToArray();
+    }
+
+    public static string FormatItems(
+        IEnumerable<ContractCargoSnapshotMessage> items,
+        string emptyText)
+    {
+        IReadOnlyList<NamedContractReportItem> summarized = SummarizeItems(items);
+        return summarized.Count == 0
+            ? emptyText
+            : string.Join(", ", summarized.Select(item =>
+                $"{item.DisplayName} q{item.Quality} x{item.Stack}"));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ efo_roster
 efo_overflow
 efo_quarantine
 efo_netstatus
+efo_report
 ```
 
 `efo_overflow` opens the persistent team inventory used only to preserve cargo already captured when a storage failure stops the contract. It is not a normal destination and never permits more harvesting. Emergency ground drops are announced explicitly and placed at the on-farm requester or a collision-free farmhouse/selected-entrance delivery tile before the worker position is considered.
@@ -85,6 +86,8 @@ efo_netstatus
 `efo_quarantine` opens the separate persistent emergency inventory used only when both ordinary overflow and a visible drop cannot be verified. Every quarantined stack carries its transfer ID. If even that inventory is temporarily unavailable, the host stores a size-bounded validated recovery record, blocks new harvest contracts, and retries exact reconstruction before allowing further harvest work. Day end, ordinary saving, and initial save creation recheck this ownership before the game writes the save; any transient remainder is forced into the private team quarantine before the contract can settle.
 
 `efo_netstatus` reports the local network role, host session, active contract, pending request, processed-request count, replay recovery health, host quarantine health, and synchronized state version for multiplayer acceptance testing.
+
+`efo_report` prints the current player's latest authoritative named-contract result without rerunning work or charging wages. It includes the worker, task, status or stop reason, completed count, grouped item/quality totals, destinations, and billing. Host reports survive a clean save/reload through the bounded recent-result ledger; farmhands read the latest validated host result synchronized for them.
 
 ### Configuration
 
@@ -155,6 +158,7 @@ efo_roster
 efo_overflow
 efo_quarantine
 efo_netstatus
+efo_report
 ```
 
 `efo_overflow` 用于打开持久化队伍溢出仓；它只保全因储存失败而终止合同时已经采下的货物，不是普通目标，也不会让工人继续收获。紧急地面掉落一定会明确提示，并优先落在仍在农场的请求者处；否则选择农舍交付区或本次入口附近无碰撞的空格，最后才考虑工人位置。
@@ -162,6 +166,8 @@ efo_netstatus
 `efo_quarantine` 用于打开独立的持久应急隔离仓；仅在普通溢出和明确掉落都无法验证时使用。每一组隔离物品都保留转移 ID。若隔离仓也暂时不可用，主机会保存经过大小限制和验证的恢复记录、禁止新的收获合同，并在允许后续收获前重试精确恢复。日终、普通保存和首次创建存档都会在写盘前再次核对货物所有权；任何仍处于临时合同中的余货都会先强制进入私有队伍隔离仓，合同才能结算。
 
 `efo_netstatus` 用于多人验收，显示本地网络角色、主机会话、活动合同、待处理请求、已处理请求数量、请求账本恢复状态、主机隔离仓恢复状态和同步状态版本。
+
+`efo_report` 只读显示当前玩家最近一份主机权威具名合同结果，不会重新执行工作或扣费。内容包括工人、任务、完成或停止原因、完成数量、按物品与品质汇总的产物、各存放去向以及工资结算。主机的最近结果会随干净存档恢复；农场工查看的是主机同步并验证后的本人最近结果。
 
 ### 配置文件
 

--- a/i18n/default.json
+++ b/i18n/default.json
@@ -171,9 +171,18 @@
   "gmcm.open-menu-key.name": "Open roster key",
   "gmcm.open-menu-key.tooltip": "Key used to open the currently available named-worker roster.",
   "gmcm.contract-settings.notice": "Work scope, task rules, and wages are defined by each named NPC contract; there is no player-centered global scan setting.",
+  "report.none": "No completed named contract report is available for this player.",
+  "report.status.completed": "completed",
+  "report.status.stopped": "stopped ({{reason}})",
+  "report.items.none": "none",
+  "report.header": "Last contract: {{worker}} · {{task}} · {{status}}.",
+  "report.work": "Work completed: {{completed}}. Produced items: {{items}}.",
+  "report.destinations": "Destinations: requester {{player}}, chest {{chest}}, overflow {{overflow}}, quarantine {{quarantine}}, dropped {{dropped}}.",
+  "report.billing": "Billing: {{hours}} hour(s), paid {{paid}}g, refunded {{refunded}}g.",
   "cmd.roster": "Open the named worker roster and choose a farm task.",
   "cmd.overflow": "Open the persistent harvest overflow inventory.",
   "cmd.quarantine": "Open the persistent emergency harvest quarantine.",
   "cmd.netstatus": "Show host-authoritative contract network diagnostics.",
+  "cmd.report": "Show the current player's most recent named contract report.",
   "cmd.roster-world-not-ready": "Load a save before opening the worker roster."
 }

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -171,9 +171,18 @@
   "gmcm.open-menu-key.name": "打开可雇佣工人名单的按键",
   "gmcm.open-menu-key.tooltip": "用于打开当前可雇佣具名工人名单的按键。",
   "gmcm.contract-settings.notice": "工作范围、任务规则和工资由每份具名 NPC 合同定义，不存在以玩家为中心的全局扫描设置。",
+  "report.none": "当前玩家还没有可查看的具名合同报告。",
+  "report.status.completed": "已完成",
+  "report.status.stopped": "已停止（{{reason}}）",
+  "report.items.none": "无",
+  "report.header": "最近合同：{{worker}} · {{task}} · {{status}}。",
+  "report.work": "完成工作：{{completed}}；产物：{{items}}。",
+  "report.destinations": "去向：请求者 {{player}}，箱子 {{chest}}，溢出仓 {{overflow}}，隔离仓 {{quarantine}}，掉落 {{dropped}}。",
+  "report.billing": "结算：{{hours}} 小时，实付 {{paid}}g，退款 {{refunded}}g。",
   "cmd.roster": "打开具名工人名单并选择农活。",
   "cmd.overflow": "打开持久化收获溢出仓。",
   "cmd.quarantine": "打开持久化收获应急隔离仓。",
   "cmd.netstatus": "显示主机权威合同的网络诊断状态。",
+  "cmd.report": "显示当前玩家最近一份具名合同报告。",
   "cmd.roster-world-not-ready": "请先载入存档，再打开可雇佣工人名单。"
 }

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -50,7 +50,8 @@ List<(string Name, Action Test)> tests = new()
     ("multiplayer stale snapshot rejection", TestMultiplayerStaleSnapshotRejection),
     ("multiplayer stale sync-state rejection", TestMultiplayerStaleSyncStateRejection),
     ("multiplayer snapshot serialization", TestMultiplayerSnapshotSerialization),
-    ("multiplayer result serialization", TestMultiplayerResultSerialization)
+    ("multiplayer result serialization", TestMultiplayerResultSerialization),
+    ("named contract report grouping", TestNamedContractReportGrouping)
 };
 
 int failures = 0;
@@ -1244,6 +1245,30 @@ static void TestMultiplayerResultSerialization()
     Equal(1, restored.ChestItems);
     Equal(4, restored.QuarantinedItems);
     Equal(13L, restored.StateVersion);
+}
+
+static void TestNamedContractReportGrouping()
+{
+    ContractCargoSnapshotMessage[] items =
+    {
+        new() { DisplayName = "Parsnip", Quality = 2, Stack = 1 },
+        new() { DisplayName = "Bean", Quality = 0, Stack = 3 },
+        new() { DisplayName = "Parsnip", Quality = 0, Stack = 4 },
+        new() { DisplayName = "Parsnip", Quality = 2, Stack = 2 }
+    };
+
+    IReadOnlyList<NamedContractReportItem> summarized =
+        NamedContractReportFormatter.SummarizeItems(items);
+    Equal(3, summarized.Count);
+    Equal(new NamedContractReportItem("Bean", 0, 3), summarized[0]);
+    Equal(new NamedContractReportItem("Parsnip", 0, 4), summarized[1]);
+    Equal(new NamedContractReportItem("Parsnip", 2, 3), summarized[2]);
+    Equal(
+        "Bean q0 x3, Parsnip q0 x4, Parsnip q2 x3",
+        NamedContractReportFormatter.FormatItems(items, "none"));
+    Equal("none", NamedContractReportFormatter.FormatItems(
+        Array.Empty<ContractCargoSnapshotMessage>(),
+        "none"));
 }
 
 static ContractStartRequestMessage NewMultiplayerRequest(long playerId)


### PR DESCRIPTION
## 变更概述

新增只读 `efo_report` 命令，让当前玩家重新查看最近一份主机权威具名合同结果。

## 修改动机

#19 来自已删除的旧全局工作原型；当前生产系统已有每位玩家最近合同结果的持久化账本，但结果只在完成时显示一次。玩家无法在之后复查工人、产物去向和工资结算。

## 主要改动

- 为多人协调器增加当前玩家最近结果的只读查询。
- 主机继续使用现有 `RecentResults`；农场工收到并验证主机结果后缓存本人报告。
- 新增 `efo_report`，显示工人、任务、完成/停止原因、完成数量、产物、去向和账单。
- 按物品显示名与品质稳定分组并汇总数量。
- 无存档或无报告时提供中英文提示。
- 更新 README、changelog 和中英文命令说明。

## 实验与验证

- `./scripts/verify-release.sh`：通过。
- 49/49 确定性测试通过；新增报告分组、排序、空报告测试。
- Release 构建：0 warnings / 0 errors。
- 格式、diff、JSON、翻译键、manifest 与发布包白名单检查通过。
- Source commit：`d8b1bc04eee61edb7aad934d2819afba371f5a7d`。
- Source tree：`ed7f41d462ca2a58051ed82baeb862d6b3370d3d`。
- ZIP SHA-256：`9996dc57df7dfa3f5caa9aa8f45803c9cb74c402e31d2c1d04aa075655c75eb9`。
- 本功能只读取已经验证的结果账本；未部署到当前运行游戏，也未执行图形验收。

## 对 Benchmark / Baseline 的影响

- 数据集：无影响。
- 评测协议：新增确定性报告汇总测试。
- 指标定义：无影响。
- Baseline：无影响。
- 结果可复现性：报告分组按显示名和品质稳定排序。

## 风险与限制

- v0.1 只提供控制台报告，不新增菜单或逐格工作明细。
- 每位玩家只保留最近一份结果，遵循现有有界恢复模型。
- 产物显示名来自主机权威结果；不同语言客户端仍显示主机保存的该物品名称。
- 查询路径不启动合同、不移动 NPC、不修改货物、不扣费。

## Multiplayer Impact

主机保存权威最近结果；农场工只缓存通过现有会话、状态版本和快照验证的本人结果。协议字段和 schema 不变。

Closes #19.