### PR TITLE
chore(release): prepare v0.1.0-beta.1 prerelease

### DIFF
--- a/.github/workflows/source-validation.yml
+++ b/.github/workflows/source-validation.yml
@@ -34,14 +34,21 @@ jobs:
           jq -e '
             .Name == "Evil Farm Owner"
             and .Author == "Aveouter"
-            and .Version == "0.1.0"
             and .UniqueID == "Aveouter.EvilFarmOwner"
             and .EntryDll == "EvilFarmOwner.dll"
             and (.UpdateKeys | index("GitHub:Aveouter/EvilFarmOwner") != null)
           ' manifest.json >/dev/null
 
-          grep -Eq '<Version>0\.1\.0</Version>' EvilFarmOwner.csproj
-          grep -Eq 'Stardew Valley SMAPI Mod · v0\.1\.0' README.md
+          manifest_version="$(jq -er '.Version | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$"))' manifest.json)"
+          project_version="$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' EvilFarmOwner.csproj)"
+          test "$project_version" = "$manifest_version"
+          grep -Fq "Stardew Valley SMAPI Mod · v$manifest_version" README.md
+          grep -Fq "## $manifest_version -" CHANGELOG.md
+
+          test -f LICENSE
+          grep -Fxq 'MIT License' LICENSE
+          grep -Fxq 'Copyright (c) 2026 Aveouter' LICENSE
+          grep -Fq '[MIT](LICENSE) © 2026 Aveouter.' README.md
 
           jq -r 'keys[]' i18n/default.json | LC_ALL=C sort > "$RUNNER_TEMP/efo-default-keys.txt"
           jq -r 'keys[]' i18n/zh.json | LC_ALL=C sort > "$RUNNER_TEMP/efo-zh-keys.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 0.1.0 - 2026-08-24
+## 0.1.0-beta.1 - 2026-08-24
+
+- Published the first explicitly non-stable test build under the MIT License.
+- Marked real remote multiplayer and forced storage-recovery scenarios as unverified release-test gates rather than claiming they passed.
 
 - Added confirmation for a visible named-NPC watering contract.
 - Added fresh availability, funds, target, and two-way path checks before dispatch.

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.1.0</Version>
+    <Version>0.1.0-beta.1</Version>
     <AssemblyName>EvilFarmOwner</AssemblyName>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/Aveouter/EvilFarmOwner</RepositoryUrl>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableAcceptanceFaults Condition="'$(EnableAcceptanceFaults)' == ''">false</EnableAcceptanceFaults>
@@ -18,6 +20,7 @@
 
   <ItemGroup>
     <Compile Remove="tests/**/*.cs" />
+    <None Update="LICENSE" CopyToOutputDirectory="PreserveNewest" />
     <None Include="manifest.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="i18n\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aveouter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </h1>
 
 <p align="center">
-  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.1.0
+  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.1.0-beta.1
 </p>
 
 <p align="center">
@@ -28,6 +28,8 @@
 ### What is Evil Farm Owner?
 
 `Evil Farm Owner` is a Stardew Valley mod for players who want to turn repetitive farm chores into paid labor.
+
+`v0.1.0-beta.1` is a public test release. Named watering and harvesting have production implementations, and multiplayer uses a host-authoritative protocol, but the real remote host/farmhand matrix and forced storage-recovery matrix are still explicitly unverified. Back up the save before testing and report issues with both peers' SMAPI logs.
 
 Press one key to review only the named adult NPCs who are currently available for hire. NPCs in protected vanilla activities such as chores, exercise, scripted animation, or movement pauses are omitted instead of being interrupted. An available adult NPC can be assigned a visible watering or harvest contract with an itemized wage, lossless harvest delivery, and a protected return to their original schedule position.
 
@@ -115,6 +117,8 @@ Mods/EvilFarmOwner/config.json
 ### 这个 Mod 是做什么的？
 
 `邪恶农场主` 是一个《星露谷物语》SMAPI Mod。它的核心玩法是：你花钱雇佣农工，把重复农活交给他们处理。
+
+`v0.1.0-beta.1` 是公开测试版本。具名浇水、收获以及主机权威多人协议均已有生产实现，但真实远程主机/农场工矩阵和强制储存恢复矩阵仍明确标记为“未验证”。测试前请备份存档；反馈问题时请同时提供两端 SMAPI 日志。
 
 当前名单只显示此刻可以雇佣的具名成年 NPC。正在做家务、锻炼、脚本动画或处于移动暂停等原版活动的 NPC 会直接从名单中隐藏，不会被强行中断。有空的成年 NPC 可以接受可见执行的浇水或收获合同；工资会逐项显示，收获成果会无损交付，NPC 完成后安全返回原位置并恢复日程。
 
@@ -214,6 +218,7 @@ Mods/EvilFarmOwner/config.json
 ### Bug List / Known Limitations
 
 - Host-authoritative multiplayer is implemented but still requires the release-gate test with a real remote host/farmhand session; split-screen alone is not accepted as proof.
+- This beta is not the stable `v0.1.0`; use a backed-up save until the remaining multiplayer and forced-recovery gates pass.
 - Named watering and multi-crop harvest contracts are visible; debris cleanup, fertilizing, planting, and automatic shipping are not part of v0.1.0.
 - Every peer must install the same Evil Farm Owner version; mismatched protocol/save/day/player/task messages are rejected without mutation.
 - Named harvest supports content-classified ordinary player-owned main-farm chests. Persistent overflow is emergency preservation after a storage-triggered stop; special or modded chest subclasses are excluded for safety.
@@ -226,4 +231,4 @@ Mods/EvilFarmOwner/config.json
 
 ## License
 
-License not yet specified.
+[MIT](LICENSE) © 2026 Aveouter.

--- a/docs/RELEASE_NOTES_0.1.0-beta.1.md
+++ b/docs/RELEASE_NOTES_0.1.0-beta.1.md
@@ -1,0 +1,43 @@
+# Evil Farm Owner v0.1.0-beta.1
+
+> **Public test release / 公开测试版本**
+>
+> Back up your save before testing. The production implementations and deterministic tests are complete, but the real remote host/farmhand matrix and forced storage-recovery matrix have not yet been run. This prerelease does not claim those gates passed.
+>
+> 测试前请备份存档。生产实现和确定性测试已经完成，但真实远程主机/农场工矩阵与强制储存恢复矩阵尚未运行；本测试版不会把这些门禁描述为已通过。
+
+## 中文
+
+- 从当前安全可雇佣的成年 NPC 中选择具名工人，查看好感度、时薪、六小时上限与休息日三倍工资。
+- 让工人从农场真实边界入口进入，绕开箱子、机器、栅栏和棚架，浇灌全部可到达的缺水作物。
+- 通过原版作物逻辑收获全部可到达的成熟作物，并按“同品质堆叠 → 同物品 → 同 `Item.Category` → 最大空箱容量”稳定分类。
+- 没有箱子能完整接收堆叠时停止继续收获；已采货物通过请求者背包、持久溢出、可见掉落或隔离恢复守恒，不会自动出售或静默消失。
+- 主机和农场工都能请求合同，但作物、金币、NPC、货物和箱子只由主机权威修改；协议支持幂等请求、阶段快照、重连和主机重启恢复。
+- 支持一份主机专用的自动合同授权，包含固定候选池、每日幂等选择、预算上限和休息日显式授权。
+
+安装：解压 ZIP，把 `EvilFarmOwner` 文件夹放入 Stardew Valley 的 `Mods` 目录。要求 Stardew Valley 1.6+、SMAPI 4.0+；联机双方必须安装完全相同的版本。
+
+## English
+
+- Select a currently safe adult NPC and review friendship, hourly wage, the six-hour cap, and explicit rest-day triple pay.
+- Workers enter through genuine farm-boundary entrances, route around chests, machines, fences, and trellises, and water every reachable dry crop.
+- Harvest every reachable mature crop through vanilla crop logic and classify exact output by compatible quality stack, same item, exact `Item.Category`, then greatest empty-chest capacity.
+- Stop further harvesting if no chest accepts the complete stack. Already harvested cargo remains conserved through requester inventory, persistent overflow, visible drop, or quarantine recovery; it is never auto-shipped or silently deleted.
+- Hosts and farmhands can request contracts, while only the host mutates crops, money, NPCs, cargo, and chests. The protocol includes idempotent requests, phase snapshots, reconnect synchronization, and host-restart recovery.
+- Configure one host-owned automatic authorization with a fixed candidate pool, once-per-day deterministic selection, hard wage caps, and explicit rest-day opt-in.
+
+Install by extracting the ZIP and placing the `EvilFarmOwner` folder in Stardew Valley's `Mods` directory. Stardew Valley 1.6+ and SMAPI 4.0+ are required. Every multiplayer peer must install this exact version.
+
+## Known limitations / 已知限制
+
+- Real two-process host/farmhand watering, harvest, duplicate-request, disconnect/reconnect, and host-restart acceptance remains unverified.
+- Forced overflow/drop/quarantine/recovery fault acceptance remains unverified and must use a disposable save.
+- Debris clearing, planting, fertilizing, automatic shipping, and special/modded chest support are not included.
+
+## Integrity / 完整性
+
+- Asset: `EvilFarmOwner 0.1.0-beta.1.zip`
+- SHA-256: `{{ZIP_SHA256}}`
+- Source commit: `{{SOURCE_COMMIT}}`
+- Source tree: `{{SOURCE_TREE}}`
+- License: MIT

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Evil Farm Owner",
   "Author": "Aveouter",
-  "Version": "0.1.0",
+  "Version": "0.1.0-beta.1",
   "Description": "Hire named adult NPCs for visible watering and lossless harvest contracts.",
   "UniqueID": "Aveouter.EvilFarmOwner",
   "EntryDll": "EvilFarmOwner.dll",

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -2,9 +2,16 @@
 set -euo pipefail
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-package_path="$project_root/bin/Release/net6.0/EvilFarmOwner 0.1.0.zip"
 
 cd "$project_root"
+
+manifest_version="$(jq -er '.Version | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$"))' manifest.json)"
+project_version="$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' EvilFarmOwner.csproj)"
+if [[ "$project_version" != "$manifest_version" ]]; then
+  echo "Project version '$project_version' does not match manifest version '$manifest_version'." >&2
+  exit 1
+fi
+package_path="$project_root/bin/Release/net6.0/EvilFarmOwner $manifest_version.zip"
 
 source_commit="$(git rev-parse HEAD)"
 source_tree="$(git rev-parse 'HEAD^{tree}')"
@@ -43,7 +50,7 @@ if [[ ! -f "$package_path" ]]; then
   exit 1
 fi
 
-expected_entries=$'EvilFarmOwner/EvilFarmOwner.dll\nEvilFarmOwner/assets/banner-v4-lowres.png\nEvilFarmOwner/assets/icon-v2.png\nEvilFarmOwner/i18n/default.json\nEvilFarmOwner/i18n/zh.json\nEvilFarmOwner/manifest.json'
+expected_entries=$'EvilFarmOwner/EvilFarmOwner.dll\nEvilFarmOwner/LICENSE\nEvilFarmOwner/assets/banner-v4-lowres.png\nEvilFarmOwner/assets/icon-v2.png\nEvilFarmOwner/i18n/default.json\nEvilFarmOwner/i18n/zh.json\nEvilFarmOwner/manifest.json'
 actual_entries="$(unzip -Z1 "$package_path" | LC_ALL=C sort)"
 if [[ "$actual_entries" != "$expected_entries" ]]; then
   echo "Release package contents differ from the allowlist:" >&2
@@ -52,14 +59,19 @@ if [[ "$actual_entries" != "$expected_entries" ]]; then
 fi
 
 unzip -p "$package_path" EvilFarmOwner/manifest.json \
-  | jq -e '
+  | jq -e --arg version "$manifest_version" '
       .Name == "Evil Farm Owner"
       and .Author == "Aveouter"
-      and .Version == "0.1.0"
+      and .Version == $version
       and .UniqueID == "Aveouter.EvilFarmOwner"
       and .EntryDll == "EvilFarmOwner.dll"
       and (.UpdateKeys | index("GitHub:Aveouter/EvilFarmOwner") != null)
     ' >/dev/null
+
+if ! cmp -s LICENSE <(unzip -p "$package_path" EvilFarmOwner/LICENSE); then
+  echo "Packaged LICENSE differs from the reviewed repository license." >&2
+  exit 1
+fi
 
 dll_search_text="$(LC_ALL=C tr -d '\000' < "$project_root/bin/Release/net6.0/EvilFarmOwner.dll")"
 if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_faults|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then


### PR DESCRIPTION
## 变更概述

为首个公开测试版 `v0.1.0-beta.1` 准备 MIT 许可证、统一版本元数据、可审计二进制包和双语 GitHub Prerelease 文案。该 PR 只处理许可、验证、打包与发布说明，不改变浇水、收获、工资、路径或多人协议算法。

Closes #52

## 修改动机

项目所有者已明确选择 MIT，并要求先发布测试版本。真实远程多人和极端储存故障验收仍缺少运行条件，因此不能把当前构建描述为稳定 `v0.1.0`；使用带明确限制声明的 prerelease 可让测试者获取完全可追溯的构建，同时保留 #33、#42 和稳定发布 #34 的门禁。

## 主要改动

- 新增标准 MIT License：`Copyright (c) 2026 Aveouter`。
- 将项目、manifest、README、changelog 和候选包统一为 `0.1.0-beta.1`。
- 将 MIT 文本随二进制 ZIP 分发，并在校验器中逐字比对仓库与包内许可证。
- 让发布脚本从 manifest 派生包名并校验项目版本，减少后续版本硬编码漂移。
- 加固 hosted source validation：版本、README、changelog、许可证和翻译键一致性。
- 新增双语测试版 Release 文案，明确未验证门禁和备份存档要求。

## 实验与验证

已在 commit `7f2d6953cd2420fb9f06c74981103ae009966b6b` / tree `dd518b6c1eed75b2456fd8cdbc02eb36ff6aa811` 实际运行：

- `./scripts/verify-release.sh`
  - 60/60 确定性逻辑/协议测试通过
  - Release rebuild：0 warnings / 0 errors
  - 7 项 ZIP allowlist、manifest 与 MIT 逐字比对通过
- `dotnet format EvilFarmOwner.csproj --verify-no-changes --no-restore`
- `dotnet format tests/EvilFarmOwner.LogicTests.csproj --verify-no-changes --no-restore`
- `git diff --check`、shell syntax、JSON、版本和中英文键一致性通过
- 候选 ZIP SHA-256：`fa8c06ade1e3e1c9594f5ab27d3a1258e5ff7c256ef2ef7d967e48900fbbea82`
- 候选 DLL SHA-256：`90022cdd2166edf6f3dfadeb2c6318063d91e241d028a8305df38df4486c6e41`

未运行：SMAPI 新游戏启动、真实双客户端、多玩家断线重连、强制储存故障。它们在文档与 Release 文案中明确为未验证，不记为通过。

## 对 Benchmark / Baseline 的影响

- 数据集：无影响
- 评测协议：无影响
- 指标定义：无影响
- Baseline：无影响
- 结果可复现性：增强；版本、源码 commit/tree、包内容、许可证和哈希均可追溯

未修改数据标签、标准答案、评分规则或 Baseline，也未删除失败样本或隐藏未运行验收。

## 风险与限制

- 这是 GitHub Prerelease，不是稳定 `v0.1.0`，必须保持 `prerelease=true`。
- #33 的真实远程主机/农场工矩阵与 #42 的强制恢复矩阵仍开放。
- 合并会改变最终源码 SHA 与二进制哈希；Release 必须从合并后的远端 `main` 重新生成，不能上传上述 PR 候选哈希。
- 测试者应使用备份存档，并在联机双方安装完全相同的 beta 版本。
