### PR TITLE
feat(storage): add deterministic chest sort planner

### DIFF
--- a/StorageSortPlanner.cs
+++ b/StorageSortPlanner.cs
@@ -1,0 +1,618 @@
+namespace EvilFarmOwner;
+
+internal enum StorageSortMatchKind
+{
+    ExactStack = 0,
+    SameItem = 1,
+    SameCategory = 2,
+    SourceAnchor = 3,
+    Empty = 4,
+    Incompatible = 5
+}
+
+internal enum StorageSortPlanFailure
+{
+    None,
+    InvalidSnapshot,
+    InsufficientCapacity,
+    NonConvergent
+}
+
+internal sealed record StorageSortStackSnapshot(
+    string StackId,
+    string StackingKey,
+    string ItemId,
+    int Category,
+    int Quantity,
+    int MaximumStackSize);
+
+internal sealed record StorageSortChestSnapshot(
+    GridPoint ChestTile,
+    int Capacity,
+    IReadOnlyList<StorageSortStackSnapshot> Stacks);
+
+internal sealed record StorageSortTransfer(
+    int Sequence,
+    GridPoint SourceChest,
+    GridPoint DestinationChest,
+    string StackId,
+    string StackingKey,
+    string ItemId,
+    int Category,
+    int Quantity);
+
+internal sealed record StorageSortPlan(
+    StorageSortPlanFailure Failure,
+    IReadOnlyList<StorageSortTransfer> Transfers,
+    IReadOnlyList<StorageSortChestSnapshot> ResultChests)
+{
+    public bool CanExecute => this.Failure == StorageSortPlanFailure.None;
+}
+
+internal static class StorageSortPlanner
+{
+    public static StorageSortPlan Create(IReadOnlyList<StorageSortChestSnapshot> chests)
+    {
+        if (!TryCreateSimulation(chests, out List<SimulatedChest>? simulated)
+            || simulated is null)
+        {
+            return Failure(StorageSortPlanFailure.InvalidSnapshot, chests);
+        }
+
+        List<StorageSortChestSnapshot> original = CreateSnapshots(simulated);
+        List<StorageSortTransfer> transfers = new();
+        HashSet<string> observedStates = new(StringComparer.Ordinal)
+        {
+            CreateStateKey(simulated)
+        };
+        int sourceStackCount = simulated.Sum(chest => chest.Stacks.Count);
+        int maximumMoves = Math.Max(1, sourceStackCount * Math.Max(2, simulated.Count) * 8);
+
+        while (true)
+        {
+            bool movedInPass = false;
+            string[] stackIds = simulated
+                .OrderBy(chest => chest.Tile.Y)
+                .ThenBy(chest => chest.Tile.X)
+                .SelectMany(chest => chest.Stacks.OrderBy(stack => stack.Order))
+                .Select(stack => stack.StackId)
+                .ToArray();
+
+            foreach (string stackId in stackIds)
+            {
+                if (!TryFindStack(simulated, stackId, out SimulatedChest? source, out SimulatedStack? stack)
+                    || source is null
+                    || stack is null)
+                {
+                    continue;
+                }
+
+                SortScore sourceScore = GetSourceScore(source, stack);
+                DestinationOption? destination = simulated
+                    .Where(chest => !ReferenceEquals(chest, source))
+                    .Select(chest => CreateDestinationOption(chest, stack))
+                    .Where(option => option is not null)
+                    .Select(option => option!)
+                    .OrderBy(option => option.Score, SortScoreComparer.Instance)
+                    .FirstOrDefault();
+
+                if (destination is null)
+                {
+                    if (sourceScore.MatchKind == StorageSortMatchKind.Incompatible)
+                        return Failure(StorageSortPlanFailure.InsufficientCapacity, original);
+                    continue;
+                }
+
+                if (SortScoreComparer.Instance.Compare(destination.Score, sourceScore) >= 0)
+                {
+                    if (sourceScore.MatchKind == StorageSortMatchKind.Incompatible)
+                        return Failure(StorageSortPlanFailure.InsufficientCapacity, original);
+                    continue;
+                }
+
+                int quantity = stack.Quantity;
+                GridPoint sourceTile = source.Tile;
+                RemoveStack(source, stack);
+                if (!TryInsertWholeStack(destination.Chest, stack))
+                    return Failure(StorageSortPlanFailure.InsufficientCapacity, original);
+
+                transfers.Add(new StorageSortTransfer(
+                    transfers.Count + 1,
+                    sourceTile,
+                    destination.Chest.Tile,
+                    stack.StackId,
+                    stack.StackingKey,
+                    stack.ItemId,
+                    stack.Category,
+                    quantity));
+                movedInPass = true;
+
+                if (transfers.Count > maximumMoves)
+                    return Failure(StorageSortPlanFailure.NonConvergent, original);
+            }
+
+            if (!movedInPass)
+                return new StorageSortPlan(StorageSortPlanFailure.None, transfers, CreateSnapshots(simulated));
+
+            string state = CreateStateKey(simulated);
+            if (!observedStates.Add(state))
+                return Failure(StorageSortPlanFailure.NonConvergent, original);
+        }
+    }
+
+    private static StorageSortPlan Failure(
+        StorageSortPlanFailure failure,
+        IReadOnlyList<StorageSortChestSnapshot>? chests)
+    {
+        return new StorageSortPlan(
+            failure,
+            Array.Empty<StorageSortTransfer>(),
+            chests?.OfType<StorageSortChestSnapshot>().Select(CloneSnapshot).ToArray()
+                ?? Array.Empty<StorageSortChestSnapshot>());
+    }
+
+    private static StorageSortChestSnapshot CloneSnapshot(StorageSortChestSnapshot chest)
+    {
+        return new StorageSortChestSnapshot(
+            chest.ChestTile,
+            chest.Capacity,
+            chest.Stacks?.OfType<StorageSortStackSnapshot>().Select(stack => stack with { }).ToArray()
+                ?? Array.Empty<StorageSortStackSnapshot>());
+    }
+
+    private static bool TryCreateSimulation(
+        IReadOnlyList<StorageSortChestSnapshot>? chests,
+        out List<SimulatedChest>? simulated)
+    {
+        simulated = null;
+        if (chests is null)
+            return false;
+
+        HashSet<GridPoint> tiles = new();
+        HashSet<string> stackIds = new(StringComparer.Ordinal);
+        List<SimulatedChest> result = new(chests.Count);
+        long order = 0;
+        foreach (StorageSortChestSnapshot? chest in chests)
+        {
+            if (chest is null
+                || chest.Capacity < 0
+                || chest.Stacks is null
+                || chest.Stacks.Count > chest.Capacity
+                || !tiles.Add(chest.ChestTile))
+            {
+                return false;
+            }
+
+            List<SimulatedStack> stacks = new(chest.Stacks.Count);
+            foreach (StorageSortStackSnapshot? stack in chest.Stacks)
+            {
+                if (stack is null
+                    || string.IsNullOrWhiteSpace(stack.StackId)
+                    || string.IsNullOrWhiteSpace(stack.StackingKey)
+                    || string.IsNullOrWhiteSpace(stack.ItemId)
+                    || stack.Quantity <= 0
+                    || stack.MaximumStackSize <= 0
+                    || stack.Quantity > stack.MaximumStackSize
+                    || !stackIds.Add(stack.StackId))
+                {
+                    return false;
+                }
+
+                stacks.Add(new SimulatedStack(
+                    stack.StackId,
+                    stack.StackingKey,
+                    stack.ItemId,
+                    stack.Category,
+                    stack.Quantity,
+                    stack.MaximumStackSize,
+                    order++));
+            }
+
+            result.Add(new SimulatedChest(
+                chest.ChestTile,
+                chest.Capacity,
+                GetDominantCategory(stacks),
+                stacks));
+        }
+
+        simulated = result;
+        return true;
+    }
+
+    private static DestinationOption? CreateDestinationOption(
+        SimulatedChest chest,
+        SimulatedStack incoming)
+    {
+        int acceptableCapacity = GetAcceptableCapacity(chest, incoming);
+        if (acceptableCapacity < incoming.Quantity)
+            return null;
+
+        StorageSortContents contents = GetContents(chest, incoming, excludedStackId: null);
+        StorageSortMatchKind? matchKind = ClassifyDestination(chest, incoming, contents);
+        if (!matchKind.HasValue)
+            return null;
+
+        return new DestinationOption(
+            chest,
+            CreateScore(
+                chest,
+                matchKind.Value,
+                contents,
+                acceptableCapacity - incoming.Quantity));
+    }
+
+    private static SortScore GetSourceScore(SimulatedChest source, SimulatedStack incoming)
+    {
+        StorageSortContents contents = GetContents(source, incoming, incoming.StackId);
+        StorageSortMatchKind matchKind;
+        if (source.PurposeCategory != incoming.Category)
+        {
+            matchKind = StorageSortMatchKind.Incompatible;
+        }
+        else if (contents.ExactStackSlots > 0)
+        {
+            matchKind = StorageSortMatchKind.ExactStack;
+        }
+        else if (contents.SameItemSlots > 0)
+        {
+            matchKind = StorageSortMatchKind.SameItem;
+        }
+        else if (contents.SameCategorySlots > 0)
+        {
+            matchKind = StorageSortMatchKind.SameCategory;
+        }
+        else
+        {
+            matchKind = StorageSortMatchKind.SourceAnchor;
+        }
+
+        int capacityWithoutIncoming = GetAcceptableCapacity(source, incoming, incoming.StackId);
+        return CreateScore(
+            source,
+            matchKind,
+            contents,
+            Math.Max(0, capacityWithoutIncoming - incoming.Quantity));
+    }
+
+    private static StorageSortMatchKind? ClassifyDestination(
+        SimulatedChest chest,
+        SimulatedStack incoming,
+        StorageSortContents contents)
+    {
+        if (chest.PurposeCategory.HasValue
+            && chest.PurposeCategory.Value != incoming.Category)
+        {
+            return null;
+        }
+        if (contents.ExactStackSlots > 0)
+            return StorageSortMatchKind.ExactStack;
+        if (contents.SameItemSlots > 0)
+            return StorageSortMatchKind.SameItem;
+        if (contents.OccupiedSlots == 0)
+            return StorageSortMatchKind.Empty;
+        return chest.PurposeCategory == incoming.Category
+            ? StorageSortMatchKind.SameCategory
+            : null;
+    }
+
+    private static SortScore CreateScore(
+        SimulatedChest chest,
+        StorageSortMatchKind matchKind,
+        StorageSortContents contents,
+        int remainingCapacity)
+    {
+        return new SortScore(
+            matchKind,
+            contents.ExactStackSlots,
+            contents.SameItemSlots,
+            contents.CategoryPurityBasisPoints,
+            contents.SameCategorySlots,
+            remainingCapacity,
+            chest.Tile);
+    }
+
+    private static StorageSortContents GetContents(
+        SimulatedChest chest,
+        SimulatedStack incoming,
+        string? excludedStackId)
+    {
+        int exactStackSlots = 0;
+        int sameItemSlots = 0;
+        int sameCategorySlots = 0;
+        int occupiedSlots = 0;
+        foreach (SimulatedStack existing in chest.Stacks)
+        {
+            if (string.Equals(existing.StackId, excludedStackId, StringComparison.Ordinal))
+                continue;
+
+            occupiedSlots++;
+            if (string.Equals(existing.StackingKey, incoming.StackingKey, StringComparison.Ordinal))
+                exactStackSlots++;
+            if (string.Equals(existing.ItemId, incoming.ItemId, StringComparison.Ordinal))
+                sameItemSlots++;
+            if (existing.Category == incoming.Category)
+                sameCategorySlots++;
+        }
+
+        return new StorageSortContents(
+            exactStackSlots,
+            sameItemSlots,
+            sameCategorySlots,
+            occupiedSlots);
+    }
+
+    private static int? GetDominantCategory(IEnumerable<SimulatedStack> stacks)
+    {
+        return stacks
+            .GroupBy(stack => stack.Category)
+            .Select(group => new
+            {
+                Category = group.Key,
+                Quantity = group.Sum(stack => (long)stack.Quantity),
+                Slots = group.Count()
+            })
+            .OrderByDescending(group => group.Quantity)
+            .ThenByDescending(group => group.Slots)
+            .ThenBy(group => group.Category)
+            .Select(group => group.Category)
+            .Cast<int?>()
+            .FirstOrDefault();
+    }
+
+    private static int GetAcceptableCapacity(
+        SimulatedChest chest,
+        SimulatedStack incoming,
+        string? excludedStackId = null)
+    {
+        long capacity = 0;
+        int occupiedSlots = 0;
+        foreach (SimulatedStack existing in chest.Stacks)
+        {
+            if (string.Equals(existing.StackId, excludedStackId, StringComparison.Ordinal))
+                continue;
+
+            occupiedSlots++;
+            if (string.Equals(existing.StackingKey, incoming.StackingKey, StringComparison.Ordinal))
+                capacity += Math.Max(0, existing.MaximumStackSize - existing.Quantity);
+        }
+
+        int emptySlots = Math.Max(0, chest.Capacity - occupiedSlots);
+        capacity += (long)emptySlots * incoming.MaximumStackSize;
+        return (int)Math.Min(int.MaxValue, capacity);
+    }
+
+    private static void RemoveStack(SimulatedChest source, SimulatedStack stack)
+    {
+        if (!source.Stacks.Remove(stack))
+            throw new InvalidOperationException("Storage sort simulation lost its source stack.");
+    }
+
+    private static bool TryInsertWholeStack(SimulatedChest destination, SimulatedStack incoming)
+    {
+        int remainder = incoming.Quantity;
+        foreach (SimulatedStack existing in destination.Stacks
+                     .Where(existing => string.Equals(
+                         existing.StackingKey,
+                         incoming.StackingKey,
+                         StringComparison.Ordinal))
+                     .OrderBy(existing => existing.Order))
+        {
+            int moved = Math.Min(remainder, Math.Max(0, existing.MaximumStackSize - existing.Quantity));
+            existing.Quantity += moved;
+            remainder -= moved;
+            if (remainder == 0)
+                return true;
+        }
+
+        if (remainder <= 0)
+            return true;
+        if (destination.Stacks.Count >= destination.Capacity
+            || remainder > incoming.MaximumStackSize)
+        {
+            return false;
+        }
+
+        destination.PurposeCategory ??= incoming.Category;
+        destination.Stacks.Add(new SimulatedStack(
+            incoming.StackId,
+            incoming.StackingKey,
+            incoming.ItemId,
+            incoming.Category,
+            remainder,
+            incoming.MaximumStackSize,
+            incoming.Order));
+        return true;
+    }
+
+    private static bool TryFindStack(
+        IEnumerable<SimulatedChest> chests,
+        string stackId,
+        out SimulatedChest? chest,
+        out SimulatedStack? stack)
+    {
+        foreach (SimulatedChest candidate in chests)
+        {
+            SimulatedStack? found = candidate.Stacks.FirstOrDefault(item =>
+                string.Equals(item.StackId, stackId, StringComparison.Ordinal));
+            if (found is null)
+                continue;
+
+            chest = candidate;
+            stack = found;
+            return true;
+        }
+
+        chest = null;
+        stack = null;
+        return false;
+    }
+
+    private static List<StorageSortChestSnapshot> CreateSnapshots(IEnumerable<SimulatedChest> chests)
+    {
+        return chests
+            .OrderBy(chest => chest.Tile.Y)
+            .ThenBy(chest => chest.Tile.X)
+            .Select(chest => new StorageSortChestSnapshot(
+                chest.Tile,
+                chest.Capacity,
+                chest.Stacks
+                    .OrderBy(stack => stack.Order)
+                    .Select(stack => new StorageSortStackSnapshot(
+                        stack.StackId,
+                        stack.StackingKey,
+                        stack.ItemId,
+                        stack.Category,
+                        stack.Quantity,
+                        stack.MaximumStackSize))
+                    .ToArray()))
+            .ToList();
+    }
+
+    private static string CreateStateKey(IEnumerable<SimulatedChest> chests)
+    {
+        System.Text.StringBuilder key = new();
+        foreach (SimulatedChest chest in chests
+                     .OrderBy(chest => chest.Tile.Y)
+                     .ThenBy(chest => chest.Tile.X))
+        {
+            key.Append(chest.Tile.X)
+                .Append(',')
+                .Append(chest.Tile.Y)
+                .Append(',')
+                .Append(chest.PurposeCategory)
+                .Append(':');
+            foreach (SimulatedStack stack in chest.Stacks.OrderBy(stack => stack.Order))
+            {
+                AppendLengthPrefixed(key, stack.StackId);
+                AppendLengthPrefixed(key, stack.StackingKey);
+                AppendLengthPrefixed(key, stack.ItemId);
+                key.Append(stack.Category)
+                    .Append(',')
+                    .Append(stack.Quantity)
+                    .Append(',')
+                    .Append(stack.MaximumStackSize)
+                    .Append(';');
+            }
+
+            key.Append('|');
+        }
+
+        return key.ToString();
+    }
+
+    private static void AppendLengthPrefixed(System.Text.StringBuilder target, string value)
+    {
+        target.Append(value.Length).Append(':').Append(value).Append(',');
+    }
+
+    private readonly record struct StorageSortContents(
+        int ExactStackSlots,
+        int SameItemSlots,
+        int SameCategorySlots,
+        int OccupiedSlots)
+    {
+        public int CategoryPurityBasisPoints => this.OccupiedSlots <= 0
+            ? 0
+            : this.SameCategorySlots * 10_000 / this.OccupiedSlots;
+    }
+
+    private readonly record struct SortScore(
+        StorageSortMatchKind MatchKind,
+        int ExactStackSlots,
+        int SameItemSlots,
+        int CategoryPurityBasisPoints,
+        int SameCategorySlots,
+        int RemainingCapacity,
+        GridPoint ChestTile);
+
+    private sealed class SortScoreComparer : IComparer<SortScore>
+    {
+        public static SortScoreComparer Instance { get; } = new();
+
+        public int Compare(SortScore left, SortScore right)
+        {
+            int result = left.MatchKind.CompareTo(right.MatchKind);
+            if (result != 0)
+                return result;
+            result = right.ExactStackSlots.CompareTo(left.ExactStackSlots);
+            if (result != 0)
+                return result;
+            result = right.SameItemSlots.CompareTo(left.SameItemSlots);
+            if (result != 0)
+                return result;
+            result = right.CategoryPurityBasisPoints.CompareTo(left.CategoryPurityBasisPoints);
+            if (result != 0)
+                return result;
+            result = right.SameCategorySlots.CompareTo(left.SameCategorySlots);
+            if (result != 0)
+                return result;
+            result = right.RemainingCapacity.CompareTo(left.RemainingCapacity);
+            if (result != 0)
+                return result;
+            result = left.ChestTile.Y.CompareTo(right.ChestTile.Y);
+            return result != 0
+                ? result
+                : left.ChestTile.X.CompareTo(right.ChestTile.X);
+        }
+    }
+
+    private sealed record DestinationOption(SimulatedChest Chest, SortScore Score);
+
+    private sealed class SimulatedChest
+    {
+        public SimulatedChest(
+            GridPoint tile,
+            int capacity,
+            int? purposeCategory,
+            List<SimulatedStack> stacks)
+        {
+            this.Tile = tile;
+            this.Capacity = capacity;
+            this.PurposeCategory = purposeCategory;
+            this.Stacks = stacks;
+        }
+
+        public GridPoint Tile { get; }
+
+        public int Capacity { get; }
+
+        public int? PurposeCategory { get; set; }
+
+        public List<SimulatedStack> Stacks { get; }
+    }
+
+    private sealed class SimulatedStack
+    {
+        public SimulatedStack(
+            string stackId,
+            string stackingKey,
+            string itemId,
+            int category,
+            int quantity,
+            int maximumStackSize,
+            long order)
+        {
+            this.StackId = stackId;
+            this.StackingKey = stackingKey;
+            this.ItemId = itemId;
+            this.Category = category;
+            this.Quantity = quantity;
+            this.MaximumStackSize = maximumStackSize;
+            this.Order = order;
+        }
+
+        public string StackId { get; }
+
+        public string StackingKey { get; }
+
+        public string ItemId { get; }
+
+        public int Category { get; }
+
+        public int Quantity { get; set; }
+
+        public int MaximumStackSize { get; }
+
+        public long Order { get; }
+    }
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -43,6 +43,14 @@ List<(string Name, Action Test)> tests = new()
     ("harvest chest full acceptance", TestHarvestChestFullAcceptance),
     ("harvest stable category destination", TestHarvestStableCategoryDestination),
     ("harvest empty chest capacity fallback", TestHarvestEmptyChestCapacityFallback),
+    ("storage sort classification priority", TestStorageSortClassificationPriority),
+    ("storage sort category purity", TestStorageSortCategoryPurity),
+    ("storage sort stable tie", TestStorageSortStableTie),
+    ("storage sort capacity preflight", TestStorageSortCapacityPreflight),
+    ("storage sort idempotence", TestStorageSortIdempotence),
+    ("storage sort conservation", TestStorageSortConservation),
+    ("storage sort invalid snapshot", TestStorageSortInvalidSnapshot),
+    ("storage sort generated invariants", TestStorageSortGeneratedInvariants),
     ("harvest partial remainder", TestHarvestPartialRemainder),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
@@ -759,6 +767,314 @@ static void TestHarvestEmptyChestCapacityFallback()
 
     IReadOnlyList<HarvestChestOption> ordered = HarvestChestRanking.Order(options);
     Equal(new GridPoint(8, 8), ordered[0].ChestTile);
+}
+
+static void TestStorageSortClassificationPriority()
+{
+    StorageSortPlan exact = StorageSortPlanner.Create(new[]
+    {
+        SortChest(0, 0, 12, SortStack("source", "carrot-q0", "carrot", -75, 10)),
+        SortChest(2, 0, 12, SortStack("exact", "carrot-q0", "carrot", -75, 5)),
+        SortChest(1, 0, 12, SortStack("same", "carrot-q1", "carrot", -75, 5)),
+        SortChest(3, 0, 12, SortStack("category", "potato-q0", "potato", -75, 5)),
+        SortChest(4, 0, 12)
+    });
+    Equal(true, exact.CanExecute);
+    Equal(new GridPoint(2, 0), exact.Transfers[0].DestinationChest);
+
+    StorageSortPlan sameItem = StorageSortPlanner.Create(new[]
+    {
+        SortChest(0, 0, 12, SortStack("source", "carrot-q0", "carrot", -75, 10)),
+        SortChest(1, 0, 12, SortStack("same", "carrot-q1", "carrot", -75, 5)),
+        SortChest(2, 0, 12, SortStack("category", "potato-q0", "potato", -75, 5)),
+        SortChest(3, 0, 12)
+    });
+    Equal(true, sameItem.CanExecute);
+    Equal(new GridPoint(1, 0), sameItem.Transfers[0].DestinationChest);
+
+    StorageSortPlan category = StorageSortPlanner.Create(new[]
+    {
+        SortChest(0, 0, 12, SortStack("source", "carrot-q0", "carrot", -75, 10)),
+        SortChest(1, 0, 12, SortStack("category", "potato-q0", "potato", -75, 5)),
+        SortChest(2, 0, 12)
+    });
+    Equal(true, category.CanExecute);
+    Equal(new GridPoint(1, 0), category.Transfers[0].DestinationChest);
+
+    StorageSortPlan emptyFallback = StorageSortPlanner.Create(new[]
+    {
+        SortChest(
+            0,
+            0,
+            12,
+            SortStack("anchor", "stone-q0", "stone", -12, 20),
+            SortStack("source", "carrot-q0", "carrot", -75, 10)),
+        SortChest(1, 0, 12)
+    });
+    Equal(true, emptyFallback.CanExecute);
+    Equal(new GridPoint(1, 0), emptyFallback.Transfers[0].DestinationChest);
+}
+
+static void TestStorageSortCategoryPurity()
+{
+    StorageSortPlan plan = StorageSortPlanner.Create(new[]
+    {
+        SortChest(
+            0,
+            0,
+            12,
+            SortStack("source", "carrot-q0", "carrot", -75, 10),
+            SortStack("source-stone", "stone-q0", "stone", -12, 1)),
+        SortChest(
+            2,
+            0,
+            12,
+            SortStack("mixed-potato", "potato-q0", "potato", -75, 20),
+            SortStack("mixed-coal", "coal-q0", "coal", -15, 19)),
+        SortChest(3, 0, 12, SortStack("pure-potato", "potato-q1", "potato", -75, 5)),
+        SortChest(4, 0, 12),
+        SortChest(5, 0, 12)
+    });
+
+    Equal(true, plan.CanExecute);
+    StorageSortTransfer carrot = plan.Transfers.First(transfer => transfer.StackId == "source");
+    Equal(new GridPoint(3, 0), carrot.DestinationChest);
+}
+
+static void TestStorageSortStableTie()
+{
+    StorageSortPlan plan = StorageSortPlanner.Create(new[]
+    {
+        SortChest(
+            0,
+            0,
+            12,
+            SortStack("anchor", "stone-q0", "stone", -12, 20),
+            SortStack("source", "carrot-q0", "carrot", -75, 10)),
+        SortChest(8, 8, 12, SortStack("late", "potato-q0", "potato", -75, 5)),
+        SortChest(2, 2, 12, SortStack("early", "parsnip-q0", "parsnip", -75, 5))
+    });
+
+    Equal(true, plan.CanExecute);
+    Equal(new GridPoint(2, 2), plan.Transfers.First().DestinationChest);
+}
+
+static void TestStorageSortCapacityPreflight()
+{
+    StorageSortPlan plan = StorageSortPlanner.Create(new[]
+    {
+        SortChest(
+            0,
+            0,
+            2,
+            SortStack("anchor", "stone-q0", "stone", -12, 20),
+            SortStack("source", "carrot-q0", "carrot", -75, 10)),
+        SortChest(1, 0, 1, SortStack("full", "fiber-q0", "fiber", -16, 999))
+    });
+
+    Equal(false, plan.CanExecute);
+    Equal(StorageSortPlanFailure.InsufficientCapacity, plan.Failure);
+    Equal(0, plan.Transfers.Count);
+    Equal(1029, SortQuantity(plan.ResultChests));
+}
+
+static void TestStorageSortIdempotence()
+{
+    StorageSortPlan first = StorageSortPlanner.Create(new[]
+    {
+        SortChest(0, 0, 12, SortStack("carrot-a", "carrot-q0", "carrot", -75, 10)),
+        SortChest(1, 0, 12, SortStack("carrot-b", "carrot-q0", "carrot", -75, 20)),
+        SortChest(
+            2,
+            0,
+            12,
+            SortStack("stone", "stone-q0", "stone", -12, 20),
+            SortStack("potato", "potato-q0", "potato", -75, 5)),
+        SortChest(3, 0, 12)
+    });
+
+    Equal(true, first.CanExecute);
+    Equal(true, first.Transfers.Count > 0);
+    StorageSortPlan second = StorageSortPlanner.Create(first.ResultChests);
+    Equal(true, second.CanExecute);
+    Equal(0, second.Transfers.Count);
+}
+
+static void TestStorageSortConservation()
+{
+    StorageSortChestSnapshot[] input =
+    {
+        SortChest(
+            0,
+            0,
+            12,
+            SortStack("stone", "stone-q0", "stone", -12, 20),
+            SortStack("carrot", "carrot-q0", "carrot", -75, 10)),
+        SortChest(1, 0, 12, SortStack("potato", "potato-q0", "potato", -75, 5)),
+        SortChest(2, 0, 12)
+    };
+
+    StorageSortPlan plan = StorageSortPlanner.Create(input);
+    Equal(true, plan.CanExecute);
+    Equal(SortQuantity(input), SortQuantity(plan.ResultChests));
+    Equal(
+        true,
+        input.SelectMany(chest => chest.Stacks)
+            .Select(stack => stack.ItemId)
+            .OrderBy(id => id)
+            .SequenceEqual(plan.ResultChests
+                .SelectMany(chest => chest.Stacks)
+                .Select(stack => stack.ItemId)
+                .OrderBy(id => id)));
+}
+
+static void TestStorageSortInvalidSnapshot()
+{
+    StorageSortPlan duplicateStackId = StorageSortPlanner.Create(new[]
+    {
+        SortChest(0, 0, 12, SortStack("duplicate", "stone-q0", "stone", -12, 20)),
+        SortChest(1, 0, 12, SortStack("duplicate", "carrot-q0", "carrot", -75, 10))
+    });
+    Equal(StorageSortPlanFailure.InvalidSnapshot, duplicateStackId.Failure);
+
+    StorageSortPlan overCapacity = StorageSortPlanner.Create(new[]
+    {
+        SortChest(
+            0,
+            0,
+            1,
+            SortStack("one", "stone-q0", "stone", -12, 20),
+            SortStack("two", "carrot-q0", "carrot", -75, 10))
+    });
+    Equal(StorageSortPlanFailure.InvalidSnapshot, overCapacity.Failure);
+
+    StorageSortPlan nullChest = StorageSortPlanner.Create(new StorageSortChestSnapshot[] { null! });
+    Equal(StorageSortPlanFailure.InvalidSnapshot, nullChest.Failure);
+
+    StorageSortPlan nullStack = StorageSortPlanner.Create(new[]
+    {
+        new StorageSortChestSnapshot(
+            new GridPoint(0, 0),
+            12,
+            new StorageSortStackSnapshot[] { null! })
+    });
+    Equal(StorageSortPlanFailure.InvalidSnapshot, nullStack.Failure);
+}
+
+static void TestStorageSortGeneratedInvariants()
+{
+    Random random = new(4207);
+    int[] categories = { -75, -79, -12 };
+    for (int sample = 0; sample < 500; sample++)
+    {
+        List<StorageSortChestSnapshot> input = new();
+        int chestCount = random.Next(2, 6);
+        int stackNumber = 0;
+        for (int chestNumber = 0; chestNumber < chestCount; chestNumber++)
+        {
+            int capacity = random.Next(1, 5);
+            List<StorageSortStackSnapshot> stacks = new();
+            int occupied = random.Next(0, capacity + 1);
+            for (int slot = 0; slot < occupied; slot++)
+            {
+                int category = categories[random.Next(categories.Length)];
+                string itemId = $"item-{category}-{random.Next(2)}";
+                int quality = random.Next(2);
+                stacks.Add(SortStack(
+                    $"stack-{sample}-{stackNumber++}",
+                    $"{itemId}-q{quality}",
+                    itemId,
+                    category,
+                    random.Next(1, 20),
+                    maximumStackSize: 20));
+            }
+
+            input.Add(SortChest(chestNumber, sample, capacity, stacks.ToArray()));
+        }
+
+        StorageSortPlan plan = StorageSortPlanner.Create(input);
+        if (plan.Failure == StorageSortPlanFailure.NonConvergent)
+        {
+            throw new InvalidOperationException(
+                $"sample={sample}; input={DescribeSortChests(input)}");
+        }
+        if (!plan.CanExecute)
+            Equal(0, plan.Transfers.Count);
+        Equal(
+            SortTotals(input),
+            SortTotals(plan.ResultChests));
+
+        if (!plan.CanExecute)
+            continue;
+
+        foreach (StorageSortChestSnapshot chest in plan.ResultChests)
+        {
+            Equal(true, chest.Stacks.Count <= chest.Capacity);
+            Equal(true, chest.Stacks.All(stack =>
+                stack.Quantity > 0 && stack.Quantity <= stack.MaximumStackSize));
+            Equal(true, chest.Stacks.Select(stack => stack.Category).Distinct().Count() <= 1);
+        }
+
+        StorageSortPlan repeated = StorageSortPlanner.Create(plan.ResultChests);
+        Equal(true, repeated.CanExecute);
+        Equal(0, repeated.Transfers.Count);
+    }
+}
+
+static StorageSortChestSnapshot SortChest(
+    int x,
+    int y,
+    int capacity,
+    params StorageSortStackSnapshot[] stacks)
+{
+    return new StorageSortChestSnapshot(new GridPoint(x, y), capacity, stacks);
+}
+
+static StorageSortStackSnapshot SortStack(
+    string stackId,
+    string stackingKey,
+    string itemId,
+    int category,
+    int quantity,
+    int maximumStackSize = 999)
+{
+    return new StorageSortStackSnapshot(
+        stackId,
+        stackingKey,
+        itemId,
+        category,
+        quantity,
+        maximumStackSize);
+}
+
+static int SortQuantity(IEnumerable<StorageSortChestSnapshot> chests)
+{
+    return chests.SelectMany(chest => chest.Stacks).Sum(stack => stack.Quantity);
+}
+
+static string SortTotals(IEnumerable<StorageSortChestSnapshot> chests)
+{
+    return string.Join(
+        '|',
+        chests
+            .SelectMany(chest => chest.Stacks)
+            .GroupBy(stack => (stack.StackingKey, stack.ItemId, stack.Category, stack.MaximumStackSize))
+            .OrderBy(group => group.Key.StackingKey, StringComparer.Ordinal)
+            .ThenBy(group => group.Key.ItemId, StringComparer.Ordinal)
+            .ThenBy(group => group.Key.Category)
+            .ThenBy(group => group.Key.MaximumStackSize)
+            .Select(group => $"{group.Key}:{group.Sum(stack => stack.Quantity)}"));
+}
+
+static string DescribeSortChests(IEnumerable<StorageSortChestSnapshot> chests)
+{
+    return string.Join(
+        '|',
+        chests.Select(chest =>
+            $"{chest.ChestTile.X},{chest.ChestTile.Y}/{chest.Capacity}:" + string.Join(
+                ';',
+                chest.Stacks.Select(stack =>
+                    $"{stack.StackId},{stack.StackingKey},{stack.Category},{stack.Quantity}"))));
 }
 
 static void TestHarvestPartialRemainder()


### PR DESCRIPTION
## 变更概述

为 #7 增加纯逻辑、确定性的箱子整理规划器。本 PR 只建立分类与容量预检核心，不向生产菜单暴露新任务，也不执行真实箱子写入。

## 修改动机

具名仓储合同在接入 NPC 行走、箱子互斥锁和多人协议之前，必须先证明同一箱子快照会得到稳定、守恒且不会振荡的搬运计划。直接在实时控制器中边看边搬会让分类目的地随内容变化，容易出现来回搬运或半途容量不足。

## 主要改动

- 以完整箱子快照推导每个箱子的固定类别归属；空箱在本次计划首次分配后保持该类别。
- 按兼容堆叠、同物品、同 `Item.Category`、空箱依次选择目的地。
- 在同级候选中按匹配内容、类别纯度、转移后容量和固定坐标排序。
- 只在目的地严格优于来源时搬运，第二次规划已整理结果时产生零次转移。
- 在实际状态变化前模拟整个计划；混合箱中的必需搬运若无法完整容纳则整体失败并返回零次转移。
- 验证重复格位、重复堆栈 ID、非法数量和超容量快照，并对循环状态 fail closed。

## 实验与验证

已运行：

```text
dotnet format EvilFarmOwner.csproj --no-restore --verify-no-changes
dotnet format tests/EvilFarmOwner.LogicTests.csproj --no-restore --verify-no-changes
dotnet build -c Release -p:EnableModDeploy=false
dotnet run -c Release --project tests/EvilFarmOwner.LogicTests.csproj
git diff --check
```

结果：

- 68/68 项确定性逻辑测试通过；
- Release 构建 0 warnings、0 errors；
- 新增 8 项箱子整理测试；
- 其中生成式门禁使用固定随机种子覆盖 500 组混合类别、品质、容量与箱子组合，并验证无循环、精确数量守恒、成功结果单类别化及二次规划零搬运；
- 未部署 Mods，未启动游戏，因为本 PR 尚无游戏内入口或世界写入。

## 对 Benchmark / Baseline 的影响

- 数据集：无影响。
- 评测协议：无影响。
- 指标定义：无影响。
- Baseline：无影响。
- 结果可复现性：固定输入、稳定坐标排序和固定随机种子测试提高规划结果可复现性。

## 风险与限制

- 本 PR 不是可玩的箱子整理功能；后续仍需 Stardew `Item` 快照适配、箱锁、NPC 控制器、报告、UI 与主机权威协议。
- 仅规划整个堆栈进入一个目的箱；不跨箱拆分。
- 特殊/模组箱、建筑内部、自动出售、玩家背包和自动重复合同仍在 #7 范围外。
- 实时箱子内容或锁状态冲突的恢复策略必须在执行层实现并单独验证。

Refs #7
