### PR TITLE
feat(storage): add runtime chest snapshot validation

### DIFF
--- a/StorageSortSnapshotService.cs
+++ b/StorageSortSnapshotService.cs
@@ -1,0 +1,413 @@
+using System.Globalization;
+using System.Xml.Serialization;
+using Microsoft.Xna.Framework;
+using StardewValley;
+using StardewValley.Locations;
+using StardewValley.Objects;
+using SObject = StardewValley.Object;
+
+namespace EvilFarmOwner;
+
+internal enum StorageSortSnapshotFailure
+{
+    None,
+    NoEligibleChest,
+    BusyChest,
+    InvalidChest,
+    InvalidItem,
+    NoTransfers,
+    InsufficientCapacity,
+    NonConvergent,
+    FarmChanged,
+    ChestChanged
+}
+
+internal sealed record StorageSortStackBinding(
+    string StackId,
+    GridPoint ChestTile,
+    int Slot,
+    StorageSortItemFingerprint Fingerprint);
+
+internal sealed record StorageSortItemFingerprint(
+    string QualifiedItemId,
+    string RuntimeType,
+    string RuntimeAssembly,
+    int Category,
+    int Quality,
+    int Quantity,
+    int MaximumStackSize,
+    string SerializedXml)
+{
+    public static bool TryCreate(Item item, out StorageSortItemFingerprint? fingerprint)
+    {
+        fingerprint = null;
+        try
+        {
+            Type runtimeType = item.GetType();
+            string qualifiedItemId = item.QualifiedItemId;
+            string? typeName = runtimeType.FullName;
+            string? assemblyName = runtimeType.Assembly.GetName().Name;
+            int maximumStackSize = item.maximumStackSize();
+            if (string.IsNullOrWhiteSpace(qualifiedItemId)
+                || string.IsNullOrWhiteSpace(typeName)
+                || string.IsNullOrWhiteSpace(assemblyName)
+                || item.Stack <= 0
+                || maximumStackSize <= 0
+                || item.Stack > maximumStackSize)
+            {
+                return false;
+            }
+
+            fingerprint = new StorageSortItemFingerprint(
+                qualifiedItemId,
+                typeName,
+                assemblyName,
+                item.Category,
+                item.Quality,
+                item.Stack,
+                maximumStackSize,
+                Serialize(item, runtimeType));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public bool Matches(Item item)
+    {
+        return TryCreate(item, out StorageSortItemFingerprint? current)
+            && current == this;
+    }
+
+    private static string Serialize(Item item, Type runtimeType)
+    {
+        XmlSerializer serializer = new(runtimeType);
+        XmlSerializerNamespaces namespaces = new();
+        namespaces.Add("", "");
+        using StringWriter writer = new(CultureInfo.InvariantCulture);
+        serializer.Serialize(writer, item, namespaces);
+        return writer.ToString();
+    }
+}
+
+internal sealed record StorageSortChestFingerprint(
+    GridPoint ChestTile,
+    int Capacity,
+    IReadOnlyList<StorageSortStackBinding> Stacks);
+
+internal static class StorageSortSnapshotValidation
+{
+    public static bool HasSameChestSet(
+        IEnumerable<GridPoint> expected,
+        IEnumerable<GridPoint> current)
+    {
+        HashSet<GridPoint> expectedSet = expected.ToHashSet();
+        HashSet<GridPoint> currentSet = current.ToHashSet();
+        return expectedSet.SetEquals(currentSet);
+    }
+
+    public static bool IsChestUnchanged(
+        StorageSortChestFingerprint expected,
+        StorageSortChestFingerprint current)
+    {
+        return expected.ChestTile == current.ChestTile
+            && expected.Capacity == current.Capacity
+            && expected.Stacks.Count == current.Stacks.Count
+            && expected.Stacks.SequenceEqual(current.Stacks);
+    }
+}
+
+internal sealed class StorageSortRuntimePlan
+{
+    private readonly IReadOnlyDictionary<GridPoint, Chest> Chests;
+    private readonly IReadOnlyDictionary<GridPoint, StorageSortChestFingerprint> ChestFingerprints;
+
+    public StorageSortRuntimePlan(
+        StorageSortPlan plan,
+        IReadOnlyDictionary<GridPoint, Chest> chests,
+        IReadOnlyDictionary<GridPoint, StorageSortChestFingerprint> chestFingerprints,
+        IReadOnlyDictionary<string, StorageSortStackBinding> stackBindings)
+    {
+        this.Plan = plan;
+        this.Chests = chests;
+        this.ChestFingerprints = chestFingerprints;
+        this.StackBindings = stackBindings;
+    }
+
+    public StorageSortPlan Plan { get; }
+
+    public IReadOnlyDictionary<string, StorageSortStackBinding> StackBindings { get; }
+
+    public bool TryValidateUnchanged(Farm farm, out StorageSortSnapshotFailure failure)
+    {
+        failure = StorageSortSnapshotFailure.None;
+        Dictionary<GridPoint, Chest> currentChests = StorageSortSnapshotService.GetEligibleChests(farm);
+        if (!StorageSortSnapshotValidation.HasSameChestSet(
+                this.Chests.Keys,
+                currentChests.Keys))
+        {
+            failure = StorageSortSnapshotFailure.FarmChanged;
+            return false;
+        }
+
+        foreach ((GridPoint tile, Chest expectedChest) in this.Chests
+                     .OrderBy(pair => pair.Key.Y)
+                     .ThenBy(pair => pair.Key.X))
+        {
+            if (!currentChests.TryGetValue(tile, out Chest? currentChest)
+                || !ReferenceEquals(currentChest, expectedChest)
+                || !HarvestChestRouter.IsEligibleChest(currentChest))
+            {
+                failure = StorageSortSnapshotFailure.ChestChanged;
+                return false;
+            }
+
+            if (StorageSortSnapshotService.IsLockedByAnotherPeer(currentChest))
+            {
+                failure = StorageSortSnapshotFailure.BusyChest;
+                return false;
+            }
+
+            if (!StorageSortSnapshotService.TryCreateChestFingerprint(
+                    tile,
+                    currentChest,
+                    out StorageSortChestFingerprint? currentFingerprint,
+                    out failure)
+                || currentFingerprint is null)
+            {
+                return false;
+            }
+
+            StorageSortChestFingerprint expected = this.ChestFingerprints[tile];
+            if (!StorageSortSnapshotValidation.IsChestUnchanged(expected, currentFingerprint))
+            {
+                failure = StorageSortSnapshotFailure.ChestChanged;
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+internal sealed record StorageSortRuntimePlanResult(
+    StorageSortSnapshotFailure Failure,
+    StorageSortRuntimePlan? RuntimePlan)
+{
+    public bool IsSuccess => this.Failure == StorageSortSnapshotFailure.None
+        && this.RuntimePlan is not null;
+}
+
+internal static class StorageSortSnapshotService
+{
+    public static StorageSortRuntimePlanResult TryCreate(Farm farm)
+    {
+        return TryCreate(GetEligibleChests(farm));
+    }
+
+    internal static StorageSortRuntimePlanResult TryCreate(
+        IReadOnlyDictionary<GridPoint, Chest> sourceChests)
+    {
+        Dictionary<GridPoint, Chest> chests = sourceChests.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value);
+        if (chests.Count == 0)
+        {
+            return new StorageSortRuntimePlanResult(
+                StorageSortSnapshotFailure.NoEligibleChest,
+                RuntimePlan: null);
+        }
+
+        List<StorageSortChestSnapshot> snapshots = new(chests.Count);
+        Dictionary<GridPoint, StorageSortChestFingerprint> fingerprints = new();
+        Dictionary<string, StorageSortStackBinding> bindings = new(StringComparer.Ordinal);
+        List<StackingClass> stackingClasses = new();
+        foreach ((GridPoint tile, Chest chest) in chests
+                     .OrderBy(pair => pair.Key.Y)
+                     .ThenBy(pair => pair.Key.X))
+        {
+            if (IsLockedByAnotherPeer(chest))
+            {
+                return new StorageSortRuntimePlanResult(
+                    StorageSortSnapshotFailure.BusyChest,
+                    RuntimePlan: null);
+            }
+
+            if (!TryCreateChestSnapshot(
+                    tile,
+                    chest,
+                    stackingClasses,
+                    out StorageSortChestSnapshot? snapshot,
+                    out StorageSortChestFingerprint? fingerprint,
+                    out StorageSortSnapshotFailure failure)
+                || snapshot is null
+                || fingerprint is null)
+            {
+                return new StorageSortRuntimePlanResult(failure, RuntimePlan: null);
+            }
+
+            snapshots.Add(snapshot);
+            fingerprints.Add(tile, fingerprint);
+            foreach (StorageSortStackBinding binding in fingerprint.Stacks)
+                bindings.Add(binding.StackId, binding);
+        }
+
+        StorageSortPlan plan = StorageSortPlanner.Create(snapshots);
+        StorageSortSnapshotFailure planFailure = plan.Failure switch
+        {
+            StorageSortPlanFailure.None when plan.Transfers.Count == 0 =>
+                StorageSortSnapshotFailure.NoTransfers,
+            StorageSortPlanFailure.None => StorageSortSnapshotFailure.None,
+            StorageSortPlanFailure.InsufficientCapacity =>
+                StorageSortSnapshotFailure.InsufficientCapacity,
+            StorageSortPlanFailure.NonConvergent => StorageSortSnapshotFailure.NonConvergent,
+            _ => StorageSortSnapshotFailure.InvalidChest
+        };
+        if (planFailure != StorageSortSnapshotFailure.None)
+            return new StorageSortRuntimePlanResult(planFailure, RuntimePlan: null);
+
+        return new StorageSortRuntimePlanResult(
+            StorageSortSnapshotFailure.None,
+            new StorageSortRuntimePlan(plan, chests, fingerprints, bindings));
+    }
+
+    internal static Dictionary<GridPoint, Chest> GetEligibleChests(Farm farm)
+    {
+        Dictionary<GridPoint, Chest> chests = new();
+        foreach (KeyValuePair<Vector2, SObject> pair in farm.objects.Pairs)
+        {
+            if (pair.Value is not Chest chest || !HarvestChestRouter.IsEligibleChest(chest))
+                continue;
+
+            GridPoint tile = new((int)pair.Key.X, (int)pair.Key.Y);
+            chests.Add(tile, chest);
+        }
+
+        return chests;
+    }
+
+    internal static bool IsLockedByAnotherPeer(Chest chest)
+    {
+        return chest.GetMutex().IsLocked() && !chest.GetMutex().IsLockHeld();
+    }
+
+    internal static bool TryCreateChestFingerprint(
+        GridPoint tile,
+        Chest chest,
+        out StorageSortChestFingerprint? fingerprint,
+        out StorageSortSnapshotFailure failure)
+    {
+        return TryCreateChestSnapshot(
+            tile,
+            chest,
+            new List<StackingClass>(),
+            out _,
+            out fingerprint,
+            out failure);
+    }
+
+    private static bool TryCreateChestSnapshot(
+        GridPoint tile,
+        Chest chest,
+        List<StackingClass> stackingClasses,
+        out StorageSortChestSnapshot? snapshot,
+        out StorageSortChestFingerprint? fingerprint,
+        out StorageSortSnapshotFailure failure)
+    {
+        snapshot = null;
+        fingerprint = null;
+        failure = StorageSortSnapshotFailure.None;
+        if (!HarvestChestRouter.IsEligibleChest(chest))
+        {
+            failure = StorageSortSnapshotFailure.InvalidChest;
+            return false;
+        }
+
+        try
+        {
+            int capacity = chest.GetActualCapacity();
+            List<StorageSortStackSnapshot> stacks = new();
+            List<StorageSortStackBinding> bindings = new();
+            for (int slot = 0; slot < chest.Items.Count; slot++)
+            {
+                Item? item = chest.Items[slot];
+                if (item is null)
+                    continue;
+
+                if (!StorageSortItemFingerprint.TryCreate(
+                        item,
+                        out StorageSortItemFingerprint? itemFingerprint)
+                    || itemFingerprint is null
+                    || !TryGetStackingKey(item, stackingClasses, out string? stackingKey)
+                    || stackingKey is null)
+                {
+                    failure = StorageSortSnapshotFailure.InvalidItem;
+                    return false;
+                }
+
+                string stackId = $"{tile.X}:{tile.Y}:{slot}";
+                stacks.Add(new StorageSortStackSnapshot(
+                    stackId,
+                    stackingKey,
+                    itemFingerprint.QualifiedItemId,
+                    itemFingerprint.Category,
+                    itemFingerprint.Quantity,
+                    itemFingerprint.MaximumStackSize));
+                bindings.Add(new StorageSortStackBinding(
+                    stackId,
+                    tile,
+                    slot,
+                    itemFingerprint));
+            }
+
+            if (capacity < 0 || stacks.Count > capacity)
+            {
+                failure = StorageSortSnapshotFailure.InvalidChest;
+                return false;
+            }
+
+            snapshot = new StorageSortChestSnapshot(tile, capacity, stacks);
+            fingerprint = new StorageSortChestFingerprint(tile, capacity, bindings);
+            return true;
+        }
+        catch
+        {
+            failure = StorageSortSnapshotFailure.InvalidChest;
+            return false;
+        }
+    }
+
+    private static bool TryGetStackingKey(
+        Item item,
+        List<StackingClass> stackingClasses,
+        out string? stackingKey)
+    {
+        stackingKey = null;
+        try
+        {
+            foreach (StackingClass stackingClass in stackingClasses)
+            {
+                bool compatibleWithEveryMember = stackingClass.Members.All(member =>
+                    item.canStackWith(member) && member.canStackWith(item));
+                if (compatibleWithEveryMember)
+                {
+                    stackingClass.Members.Add(item);
+                    stackingKey = stackingClass.Key;
+                    return true;
+                }
+            }
+
+            stackingKey = $"stack-class-{stackingClasses.Count:D4}";
+            stackingClasses.Add(new StackingClass(stackingKey, new List<Item> { item }));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private sealed record StackingClass(string Key, List<Item> Members);
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -51,6 +51,7 @@ List<(string Name, Action Test)> tests = new()
     ("storage sort conservation", TestStorageSortConservation),
     ("storage sort invalid snapshot", TestStorageSortInvalidSnapshot),
     ("storage sort generated invariants", TestStorageSortGeneratedInvariants),
+    ("storage snapshot validation", TestStorageSnapshotValidation),
     ("harvest partial remainder", TestHarvestPartialRemainder),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
@@ -1019,6 +1020,62 @@ static void TestStorageSortGeneratedInvariants()
         Equal(true, repeated.CanExecute);
         Equal(0, repeated.Transfers.Count);
     }
+}
+
+static void TestStorageSnapshotValidation()
+{
+    GridPoint firstTile = new(1, 2);
+    GridPoint secondTile = new(3, 4);
+    Equal(true, StorageSortSnapshotValidation.HasSameChestSet(
+        new[] { firstTile, secondTile },
+        new[] { secondTile, firstTile }));
+    Equal(false, StorageSortSnapshotValidation.HasSameChestSet(
+        new[] { firstTile },
+        new[] { firstTile, secondTile }));
+
+    StorageSortItemFingerprint item = new(
+        "(O)24",
+        "StardewValley.Object",
+        "Stardew Valley",
+        Category: -75,
+        Quality: 0,
+        Quantity: 10,
+        MaximumStackSize: 999,
+        SerializedXml: "carrot");
+    StorageSortChestFingerprint expected = new(
+        firstTile,
+        Capacity: 36,
+        new[]
+        {
+            new StorageSortStackBinding("1:2:0", firstTile, Slot: 0, item)
+        });
+    StorageSortChestFingerprint unchanged = new(
+        firstTile,
+        Capacity: 36,
+        new[]
+        {
+            new StorageSortStackBinding("1:2:0", firstTile, Slot: 0, item with { })
+        });
+    StorageSortChestFingerprint changed = new(
+        firstTile,
+        Capacity: 36,
+        new[]
+        {
+            new StorageSortStackBinding(
+                "1:2:0",
+                firstTile,
+                Slot: 0,
+                item with { Quantity = 9 })
+        });
+
+    Equal(true, StorageSortSnapshotValidation.IsChestUnchanged(expected, unchanged));
+    Equal(false, StorageSortSnapshotValidation.IsChestUnchanged(expected, changed));
+    Equal(false, StorageSortSnapshotValidation.IsChestUnchanged(
+        expected,
+        unchanged with { Capacity = 48 }));
+    Equal(false, StorageSortSnapshotValidation.IsChestUnchanged(
+        expected,
+        unchanged with { ChestTile = secondTile }));
 }
 
 static StorageSortChestSnapshot SortChest(


### PR DESCRIPTION
## 变更概述

为 #7 增加真实 Stardew `Farm / Chest / Item` 到确定性整理规划器的只读适配层。本 PR 生成可验证的运行时计划，但不移动物品、不扣钱、不租用 NPC，也不向菜单或多人协议暴露新任务。

## 修改动机

PR #54 已证明纯分类算法稳定，但真实执行前仍需要明确哪些箱子可参与、哪些物品能实际堆叠，以及合同确认后箱子内容是否发生变化。若直接用 `QualifiedItemId` 或品质猜测堆叠关系，会遗漏保留物、模组数据等元数据；若忽略箱锁或内容变化，则预计算容量可能失效。

## 主要改动

- 只读取主农场中与现有收获规则一致的普通玩家箱子；特殊、全局和模组箱子继续排除。
- 在读取前拒绝由其他 peer 持锁的箱子。
- 按固定箱子坐标和槽位建立稳定 stack ID。
- 使用双向、全类别成员兼容的 `Item.canStackWith` 建立堆叠等价类，避免仅凭物品 ID 猜测。
- 使用 Qualified ID、运行时类型/程序集、类别、品质、数量、最大堆叠和完整 XML 建立不可变物品指纹。
- 将真实快照送入已合并的完整容量规划器，并明确返回无箱子、忙碌、无搬运、容量不足、非法物品和非收敛状态。
- 提供运行时复核：箱集合、对象引用、资格、锁、容量、槽位和物品指纹任一变化都会 fail closed。

## 实验与验证

已运行：

```text
dotnet format EvilFarmOwner.csproj --no-restore --verify-no-changes
dotnet format tests/EvilFarmOwner.LogicTests.csproj --no-restore --verify-no-changes
dotnet build -c Release -p:EnableModDeploy=false --no-restore
dotnet run -c Release --project tests/EvilFarmOwner.LogicTests.csproj
git diff --check
```

结果：

- 69/69 项确定性逻辑测试通过；
- Release 构建 0 warnings、0 errors；
- 新增纯逻辑快照集合、容量、槽位和物品指纹变化回归测试；
- 既有 500 组固定种子的箱子规划生成式门禁继续通过；
- 本机 ARM64 测试宿主不能加载 x86_64 Stardew/SMAPI 程序集，所以真实 `Item` XML 与 `Chest` 读取只由生产编译覆盖，必须在后续 x86_64 SMAPI 实机验收中验证；此限制没有被标记为已通过。

## 对 Benchmark / Baseline 的影响

- 数据集：无影响。
- 评测协议：无影响。
- 指标定义：无影响。
- Baseline：无影响。
- 结果可复现性：真实箱子内容现在转换为固定坐标、固定槽位和完整元数据指纹，降低平台外的隐式分类差异。

## 风险与限制

- 本 PR 仍是只读层，不是可玩的整理合同。
- “未被其他 peer 持锁”只用于安全生成/复核运行时计划；执行层仍必须逐箱获取 mutex、再次验证并在写入后确认守恒，不能依赖这次预检消除 TOCTOU。
- XML 指纹对任何无法序列化的自定义物品采取拒绝策略，不会尝试降级或猜测。
- NPC 行走、动画、工资、报告、UI、保存恢复与主机权威消息仍需后续 PR。

Refs #7
