### PR TITLE
feat(storage): add locked chest transfer transaction

### DIFF
--- a/StorageSortLockedTransferService.cs
+++ b/StorageSortLockedTransferService.cs
@@ -1,0 +1,384 @@
+using StardewValley;
+using StardewValley.Locations;
+using StardewValley.Objects;
+
+namespace EvilFarmOwner;
+
+internal enum StorageSortLockedTransferFailure
+{
+    None,
+    InvalidSequence,
+    MissingChest,
+    SourceLockNotHeld,
+    DestinationLockNotHeld,
+    SourceChanged,
+    DestinationChanged,
+    SourceItemMissing,
+    InsufficientCapacity,
+    CommitFailed,
+    RollbackFailed
+}
+
+internal sealed record StorageSortLockedTransferResult(
+    StorageSortLockedTransferFailure Failure,
+    int MovedItems,
+    bool RequiresPersistentRecovery)
+{
+    public bool IsSuccess => this.Failure == StorageSortLockedTransferFailure.None;
+}
+
+internal readonly record struct StorageSortLockPair(GridPoint First, GridPoint Second);
+
+internal static class StorageSortTransferPolicy
+{
+    public static StorageSortLockPair GetLockOrder(GridPoint source, GridPoint destination)
+    {
+        return CompareTiles(source, destination) <= 0
+            ? new StorageSortLockPair(source, destination)
+            : new StorageSortLockPair(destination, source);
+    }
+
+    public static bool IsExpectedTransfer(
+        IReadOnlyList<StorageSortTransfer> transfers,
+        int nextSequence,
+        StorageSortTransfer candidate)
+    {
+        return nextSequence > 0
+            && nextSequence <= transfers.Count
+            && candidate.Sequence == nextSequence
+            && transfers[nextSequence - 1] == candidate;
+    }
+
+    private static int CompareTiles(GridPoint left, GridPoint right)
+    {
+        int result = left.Y.CompareTo(right.Y);
+        return result != 0 ? result : left.X.CompareTo(right.X);
+    }
+}
+
+internal static class StorageSortTransferAudit
+{
+    public static bool IsConserved(
+        int expected,
+        int destination,
+        int restoredSource,
+        int quarantine,
+        int unresolved)
+    {
+        if (expected < 0
+            || destination < 0
+            || restoredSource < 0
+            || quarantine < 0
+            || unresolved < 0)
+        {
+            return false;
+        }
+
+        return expected == (long)destination + restoredSource + quarantine + unresolved;
+    }
+}
+
+internal sealed class StorageSortExecutionSession
+{
+    private readonly StorageSortRuntimePlan RuntimePlan;
+    private readonly Dictionary<GridPoint, StorageSortChestFingerprint> ExpectedChestFingerprints;
+    private readonly Dictionary<string, Item> StackItems;
+
+    private StorageSortExecutionSession(
+        StorageSortRuntimePlan runtimePlan,
+        Dictionary<GridPoint, StorageSortChestFingerprint> expectedChestFingerprints,
+        Dictionary<string, Item> stackItems)
+    {
+        this.RuntimePlan = runtimePlan;
+        this.ExpectedChestFingerprints = expectedChestFingerprints;
+        this.StackItems = stackItems;
+    }
+
+    public int NextSequence { get; private set; } = 1;
+
+    public static bool TryCreate(
+        Farm farm,
+        StorageSortRuntimePlan runtimePlan,
+        out StorageSortExecutionSession? session,
+        out StorageSortSnapshotFailure failure)
+    {
+        session = null;
+        if (!runtimePlan.TryValidateUnchanged(farm, out failure))
+            return false;
+
+        Dictionary<string, Item> stackItems = new(StringComparer.Ordinal);
+        foreach ((string stackId, StorageSortStackBinding binding) in runtimePlan.StackBindings)
+        {
+            if (!runtimePlan.RuntimeChests.TryGetValue(binding.ChestTile, out Chest? chest)
+                || binding.Slot < 0
+                || binding.Slot >= chest.Items.Count)
+            {
+                failure = StorageSortSnapshotFailure.ChestChanged;
+                return false;
+            }
+
+            Item? item = chest.Items[binding.Slot];
+            if (item is null || !binding.Fingerprint.Matches(item))
+            {
+                failure = StorageSortSnapshotFailure.ChestChanged;
+                return false;
+            }
+
+            stackItems.Add(stackId, item);
+        }
+
+        session = new StorageSortExecutionSession(
+            runtimePlan,
+            runtimePlan.InitialChestFingerprints.ToDictionary(
+                pair => pair.Key,
+                pair => pair.Value),
+            stackItems);
+        failure = StorageSortSnapshotFailure.None;
+        return true;
+    }
+
+    public StorageSortLockedTransferResult TryExecuteLocked(StorageSortTransfer transfer)
+    {
+        if (!StorageSortTransferPolicy.IsExpectedTransfer(
+                this.RuntimePlan.Plan.Transfers,
+                this.NextSequence,
+                transfer))
+        {
+            return Failure(StorageSortLockedTransferFailure.InvalidSequence);
+        }
+
+        if (!this.RuntimePlan.RuntimeChests.TryGetValue(transfer.SourceChest, out Chest? source)
+            || !this.RuntimePlan.RuntimeChests.TryGetValue(
+                transfer.DestinationChest,
+                out Chest? destination)
+            || ReferenceEquals(source, destination))
+        {
+            return Failure(StorageSortLockedTransferFailure.MissingChest);
+        }
+
+        if (!source.GetMutex().IsLockHeld())
+            return Failure(StorageSortLockedTransferFailure.SourceLockNotHeld);
+        if (!destination.GetMutex().IsLockHeld())
+            return Failure(StorageSortLockedTransferFailure.DestinationLockNotHeld);
+
+        if (!this.IsChestExpected(transfer.SourceChest, source))
+            return Failure(StorageSortLockedTransferFailure.SourceChanged);
+        if (!this.IsChestExpected(transfer.DestinationChest, destination))
+            return Failure(StorageSortLockedTransferFailure.DestinationChanged);
+
+        if (!this.StackItems.TryGetValue(transfer.StackId, out Item? sourceItem)
+            || sourceItem.Stack != transfer.Quantity
+            || sourceItem.QualifiedItemId != transfer.ItemId
+            || sourceItem.Category != transfer.Category)
+        {
+            return Failure(StorageSortLockedTransferFailure.SourceItemMissing);
+        }
+
+        int sourceSlot = source.Items.IndexOf(sourceItem);
+        if (sourceSlot < 0)
+            return Failure(StorageSortLockedTransferFailure.SourceItemMissing);
+        if (GetSymmetricAcceptableCapacity(destination, sourceItem) < sourceItem.Stack)
+            return Failure(StorageSortLockedTransferFailure.InsufficientCapacity);
+
+        StorageSortChestFingerprint expectedSource = this.ExpectedChestFingerprints[transfer.SourceChest];
+        StorageSortChestFingerprint expectedDestination =
+            this.ExpectedChestFingerprints[transfer.DestinationChest];
+        List<(Item Item, int Stack)> destinationStacks = destination.Items
+            .Where(item => item is not null
+                && item.canStackWith(sourceItem)
+                && sourceItem.canStackWith(item))
+            .Select(item => (item!, item!.Stack))
+            .ToList();
+        int originalQuantity = sourceItem.Stack;
+        bool removedFromSource = false;
+        bool addedToDestination = false;
+
+        try
+        {
+            source.Items.RemoveAt(sourceSlot);
+            removedFromSource = true;
+
+            int remainder = originalQuantity;
+            foreach ((Item existing, _) in destinationStacks)
+            {
+                int moved = Math.Min(
+                    remainder,
+                    Math.Max(0, existing.maximumStackSize() - existing.Stack));
+                existing.Stack += moved;
+                remainder -= moved;
+                if (remainder == 0)
+                    break;
+            }
+
+            if (remainder > 0)
+            {
+                if (destination.Items.Count >= destination.GetActualCapacity())
+                    throw new InvalidOperationException("Destination lost the preflight empty slot.");
+
+                sourceItem.Stack = remainder;
+                destination.Items.Add(sourceItem);
+                addedToDestination = true;
+            }
+
+            int destinationBefore = destinationStacks.Sum(entry => entry.Stack);
+            int destinationAfter = destinationStacks.Sum(entry => entry.Item.Stack)
+                + (addedToDestination ? sourceItem.Stack : 0);
+            if (destinationAfter - destinationBefore != originalQuantity
+                || source.Items.Contains(sourceItem)
+                || (addedToDestination && !destination.Items.Contains(sourceItem)))
+            {
+                throw new InvalidOperationException("Locked transfer failed its immediate conservation audit.");
+            }
+
+            if (!TryCreateFingerprint(
+                    transfer.SourceChest,
+                    source,
+                    out StorageSortChestFingerprint? committedSource)
+                || !TryCreateFingerprint(
+                    transfer.DestinationChest,
+                    destination,
+                    out StorageSortChestFingerprint? committedDestination)
+                || committedSource is null
+                || committedDestination is null)
+            {
+                throw new InvalidOperationException("Locked transfer could not fingerprint its committed state.");
+            }
+
+            this.ExpectedChestFingerprints[transfer.SourceChest] = committedSource;
+            this.ExpectedChestFingerprints[transfer.DestinationChest] = committedDestination;
+            if (!addedToDestination)
+                this.StackItems.Remove(transfer.StackId);
+            this.NextSequence++;
+            return new StorageSortLockedTransferResult(
+                StorageSortLockedTransferFailure.None,
+                originalQuantity,
+                RequiresPersistentRecovery: false);
+        }
+        catch
+        {
+            bool rolledBack = this.TryRollback(
+                source,
+                destination,
+                sourceItem,
+                sourceSlot,
+                originalQuantity,
+                destinationStacks,
+                removedFromSource,
+                addedToDestination,
+                expectedSource,
+                expectedDestination);
+            return rolledBack
+                ? Failure(StorageSortLockedTransferFailure.CommitFailed)
+                : new StorageSortLockedTransferResult(
+                    StorageSortLockedTransferFailure.RollbackFailed,
+                    MovedItems: 0,
+                    RequiresPersistentRecovery: true);
+        }
+    }
+
+    private bool IsChestExpected(GridPoint tile, Chest chest)
+    {
+        return StorageSortSnapshotService.TryCreateChestFingerprint(
+                tile,
+                chest,
+                out StorageSortChestFingerprint? current,
+                out _)
+            && current is not null
+            && StorageSortSnapshotValidation.IsChestUnchanged(
+                this.ExpectedChestFingerprints[tile],
+                current);
+    }
+
+    private static bool TryCreateFingerprint(
+        GridPoint tile,
+        Chest chest,
+        out StorageSortChestFingerprint? fingerprint)
+    {
+        return StorageSortSnapshotService.TryCreateChestFingerprint(
+                tile,
+                chest,
+                out fingerprint,
+                out _)
+            && fingerprint is not null;
+    }
+
+    private static int GetSymmetricAcceptableCapacity(Chest chest, Item incoming)
+    {
+        long capacity = 0;
+        int occupiedSlots = 0;
+        foreach (Item? existing in chest.Items)
+        {
+            if (existing is null)
+                continue;
+
+            occupiedSlots++;
+            if (existing.canStackWith(incoming) && incoming.canStackWith(existing))
+                capacity += Math.Max(0, existing.maximumStackSize() - existing.Stack);
+        }
+
+        int emptySlots = Math.Max(0, chest.GetActualCapacity() - occupiedSlots);
+        capacity += (long)emptySlots * Math.Max(1, incoming.maximumStackSize());
+        return (int)Math.Min(int.MaxValue, capacity);
+    }
+
+    private bool TryRollback(
+        Chest source,
+        Chest destination,
+        Item sourceItem,
+        int sourceSlot,
+        int originalQuantity,
+        IReadOnlyList<(Item Item, int Stack)> destinationStacks,
+        bool removedFromSource,
+        bool addedToDestination,
+        StorageSortChestFingerprint expectedSource,
+        StorageSortChestFingerprint expectedDestination)
+    {
+        try
+        {
+            if (addedToDestination)
+                destination.Items.Remove(sourceItem);
+            foreach ((Item item, int stack) in destinationStacks)
+                item.Stack = stack;
+
+            sourceItem.Stack = originalQuantity;
+            if (removedFromSource && !source.Items.Contains(sourceItem))
+            {
+                if (sourceSlot <= source.Items.Count)
+                    source.Items.Insert(sourceSlot, sourceItem);
+                else
+                    source.Items.Add(sourceItem);
+            }
+
+            bool sourceRestored = StorageSortSnapshotService.TryCreateChestFingerprint(
+                    expectedSource.ChestTile,
+                    source,
+                    out StorageSortChestFingerprint? actualSource,
+                    out _)
+                && actualSource is not null
+                && StorageSortSnapshotValidation.IsChestUnchanged(expectedSource, actualSource);
+            bool destinationRestored = StorageSortSnapshotService.TryCreateChestFingerprint(
+                    expectedDestination.ChestTile,
+                    destination,
+                    out StorageSortChestFingerprint? actualDestination,
+                    out _)
+                && actualDestination is not null
+                && StorageSortSnapshotValidation.IsChestUnchanged(
+                    expectedDestination,
+                    actualDestination);
+            return sourceRestored && destinationRestored;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static StorageSortLockedTransferResult Failure(
+        StorageSortLockedTransferFailure failure)
+    {
+        return new StorageSortLockedTransferResult(
+            failure,
+            MovedItems: 0,
+            RequiresPersistentRecovery: false);
+    }
+}

--- a/StorageSortSnapshotService.cs
+++ b/StorageSortSnapshotService.cs
@@ -140,6 +140,11 @@ internal sealed class StorageSortRuntimePlan
 
     public IReadOnlyDictionary<string, StorageSortStackBinding> StackBindings { get; }
 
+    internal IReadOnlyDictionary<GridPoint, Chest> RuntimeChests => this.Chests;
+
+    internal IReadOnlyDictionary<GridPoint, StorageSortChestFingerprint> InitialChestFingerprints =>
+        this.ChestFingerprints;
+
     public bool TryValidateUnchanged(Farm farm, out StorageSortSnapshotFailure failure)
     {
         failure = StorageSortSnapshotFailure.None;

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -52,6 +52,9 @@ List<(string Name, Action Test)> tests = new()
     ("storage sort invalid snapshot", TestStorageSortInvalidSnapshot),
     ("storage sort generated invariants", TestStorageSortGeneratedInvariants),
     ("storage snapshot validation", TestStorageSnapshotValidation),
+    ("storage transfer lock order", TestStorageTransferLockOrder),
+    ("storage transfer sequence", TestStorageTransferSequence),
+    ("storage transfer conservation", TestStorageTransferConservation),
     ("harvest partial remainder", TestHarvestPartialRemainder),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
@@ -1076,6 +1079,84 @@ static void TestStorageSnapshotValidation()
     Equal(false, StorageSortSnapshotValidation.IsChestUnchanged(
         expected,
         unchanged with { ChestTile = secondTile }));
+}
+
+static void TestStorageTransferLockOrder()
+{
+    GridPoint earlier = new(8, 2);
+    GridPoint later = new(1, 3);
+    Equal(new StorageSortLockPair(earlier, later),
+        StorageSortTransferPolicy.GetLockOrder(later, earlier));
+    Equal(new StorageSortLockPair(earlier, later),
+        StorageSortTransferPolicy.GetLockOrder(earlier, later));
+
+    GridPoint left = new(1, 5);
+    GridPoint right = new(9, 5);
+    Equal(new StorageSortLockPair(left, right),
+        StorageSortTransferPolicy.GetLockOrder(right, left));
+}
+
+static void TestStorageTransferSequence()
+{
+    StorageSortTransfer first = new(
+        Sequence: 1,
+        SourceChest: new GridPoint(1, 1),
+        DestinationChest: new GridPoint(2, 2),
+        StackId: "stack-1",
+        StackingKey: "carrot-q0",
+        ItemId: "(O)24",
+        Category: -75,
+        Quantity: 10);
+    StorageSortTransfer second = first with
+    {
+        Sequence = 2,
+        StackId = "stack-2",
+        Quantity = 5
+    };
+    StorageSortTransfer[] transfers = { first, second };
+
+    Equal(true, StorageSortTransferPolicy.IsExpectedTransfer(transfers, 1, first));
+    Equal(false, StorageSortTransferPolicy.IsExpectedTransfer(transfers, 1, second));
+    Equal(true, StorageSortTransferPolicy.IsExpectedTransfer(transfers, 2, second));
+    Equal(false, StorageSortTransferPolicy.IsExpectedTransfer(transfers, 3, second));
+    Equal(false, StorageSortTransferPolicy.IsExpectedTransfer(
+        transfers,
+        1,
+        first with { Quantity = 9 }));
+}
+
+static void TestStorageTransferConservation()
+{
+    Equal(true, StorageSortTransferAudit.IsConserved(
+        expected: 20,
+        destination: 20,
+        restoredSource: 0,
+        quarantine: 0,
+        unresolved: 0));
+    Equal(true, StorageSortTransferAudit.IsConserved(
+        expected: 20,
+        destination: 0,
+        restoredSource: 20,
+        quarantine: 0,
+        unresolved: 0));
+    Equal(true, StorageSortTransferAudit.IsConserved(
+        expected: 20,
+        destination: 7,
+        restoredSource: 0,
+        quarantine: 8,
+        unresolved: 5));
+    Equal(false, StorageSortTransferAudit.IsConserved(
+        expected: 20,
+        destination: 20,
+        restoredSource: 1,
+        quarantine: 0,
+        unresolved: 0));
+    Equal(false, StorageSortTransferAudit.IsConserved(
+        expected: 20,
+        destination: -1,
+        restoredSource: 21,
+        quarantine: 0,
+        unresolved: 0));
 }
 
 static StorageSortChestSnapshot SortChest(


### PR DESCRIPTION
## 变更概述

为确定性箱子整理计划增加运行时双箱事务核心：只有来源箱和目标箱均已持锁、内容指纹仍与计划一致时才执行完整栈搬运。

## 修改动机

#7 要求运行时冲突不能复制、删除或静默遗失物品。规划和快照层已经合并，但实际搬运还需要锁顺序、提交核验与精确回滚边界。

## 主要改动

- 以稳定格坐标顺序定义双箱锁顺序，避免不同转移反向取锁。
- 严格按预计算 transfer sequence 执行，拒绝跳步或替换参数。
- 执行前复核双箱完整指纹、源物品引用/身份/类别/数量及目标完整容量。
- 仅将双向 `canStackWith` 兼容视为可堆叠，保持规划快照与运行时一致。
- 成功后进行即时数量守恒审计，并原子刷新两个箱子的预期指纹。
- 提交异常时恢复目标栈数量和源箱原槽位；恢复验证失败返回必须进入持久恢复机制的硬故障。
- 增加锁顺序、严格序列与守恒审计测试。

## 实验与验证

- `dotnet format --verify-no-changes`
- `dotnet build -c Release -p:EnableModDeploy=false`：0 warning / 0 error
- `dotnet run --project tests -c Release --no-build`：72/72 passed
- `git diff --check`

## Benchmark/Baseline impact

本层每次转移只重新指纹化两个已锁箱子；未增加逐帧扫描。规划算法基线与固定种子 500 例不变量门禁保持通过。

## 风险与限制

- 该 PR 只提供未开放给 UI 的事务核心，不会启动 NPC 或执行玩家合同。
- `RollbackFailed` 目前只输出必须持久恢复的硬信号；接入合同控制器时必须先连通现有 quarantine/recovery，再开放执行入口。
- ARM64 测试宿主无法加载游戏 x86_64 程序集，真实 Chest/Item/mutex 行为仍需后续 SMAPI 一次性存档验收。
- 多人主机权威消息、NPC 可视化、报告和 UI 均留在 #7 后续切片。

Refs #7