### PR TITLE
feat(storage): persist failed sort transfers

### DIFF
--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -15,6 +15,7 @@ public sealed class ModEntry : Mod
     private WorkerRosterService? WorkerRoster;
     private WateringContractExecutionController? WateringContracts;
     private HarvestingContractExecutionController? HarvestingContracts;
+    private StorageSortRecoveryManager? StorageSortRecovery;
     private MultiplayerContractCoordinator? MultiplayerContracts;
     private RecurringContractCoordinator? RecurringContracts;
     private readonly HarvestAcceptanceFaults AcceptanceFaults = new();
@@ -34,6 +35,7 @@ public sealed class ModEntry : Mod
             this.Monitor,
             this.WorkerRoster,
             this.AcceptanceFaults);
+        this.StorageSortRecovery = new StorageSortRecoveryManager(this.Monitor);
         this.MultiplayerContracts = new MultiplayerContractCoordinator(
             helper,
             this.ModManifest,
@@ -167,6 +169,7 @@ public sealed class ModEntry : Mod
 
     private void OnSaveLoaded(object? sender, SaveLoadedEventArgs e)
     {
+        this.StorageSortRecovery?.OnSaveLoaded();
         this.HarvestingContracts?.OnSaveLoaded();
         this.MultiplayerContracts?.OnSaveLoaded();
         this.RecurringContracts?.OnSaveLoaded();
@@ -261,6 +264,7 @@ public sealed class ModEntry : Mod
     {
         this.WateringContracts?.Update();
         this.HarvestingContracts?.Update();
+        this.StorageSortRecovery?.Update();
         this.MultiplayerContracts?.Update();
         this.RecurringContracts?.Update(this.HasActiveNamedContract());
     }
@@ -295,6 +299,7 @@ public sealed class ModEntry : Mod
     {
         this.WateringContracts?.OnReturnedToTitle();
         this.HarvestingContracts?.OnReturnedToTitle();
+        this.StorageSortRecovery?.OnReturnedToTitle();
         this.MultiplayerContracts?.Update();
         this.MultiplayerContracts?.OnReturnedToTitle();
         this.RecurringContracts?.OnReturnedToTitle();
@@ -477,7 +482,8 @@ public sealed class ModEntry : Mod
             return;
         }
 
-        if (this.HarvestingContracts?.TryRecoverQuarantinedCargo() != true)
+        if (this.StorageSortRecovery?.TryRecover() != true
+            || this.HarvestingContracts?.TryRecoverQuarantinedCargo() != true)
             return;
 
         NetMutex mutex = Game1.player.team.GetOrCreateGlobalInventoryMutex(

--- a/StorageSortLockedTransferService.cs
+++ b/StorageSortLockedTransferService.cs
@@ -22,7 +22,9 @@ internal enum StorageSortLockedTransferFailure
 internal sealed record StorageSortLockedTransferResult(
     StorageSortLockedTransferFailure Failure,
     int MovedItems,
-    bool RequiresPersistentRecovery)
+    int PersistedRecoveryItems,
+    bool RequiresPersistentRecovery,
+    Item? UnresolvedItem)
 {
     public bool IsSuccess => this.Failure == StorageSortLockedTransferFailure.None;
 }
@@ -75,6 +77,38 @@ internal static class StorageSortTransferAudit
         }
 
         return expected == (long)destination + restoredSource + quarantine + unresolved;
+    }
+}
+
+internal static class StorageSortRecoveryValidation
+{
+    public static bool IsSourceWithoutTransfer(
+        string removedStackId,
+        StorageSortChestFingerprint expected,
+        StorageSortChestFingerprint actual)
+    {
+        if (string.IsNullOrWhiteSpace(removedStackId)
+            || expected.ChestTile != actual.ChestTile
+            || expected.Capacity != actual.Capacity
+            || expected.Stacks.Count(binding => string.Equals(
+                binding.StackId,
+                removedStackId,
+                StringComparison.Ordinal)) != 1)
+        {
+            return false;
+        }
+
+        StorageSortItemFingerprint[] expectedItems = expected.Stacks
+            .Where(binding => !string.Equals(
+                binding.StackId,
+                removedStackId,
+                StringComparison.Ordinal))
+            .Select(binding => binding.Fingerprint)
+            .ToArray();
+        StorageSortItemFingerprint[] actualItems = actual.Stacks
+            .Select(binding => binding.Fingerprint)
+            .ToArray();
+        return expectedItems.SequenceEqual(actualItems);
     }
 }
 
@@ -137,8 +171,15 @@ internal sealed class StorageSortExecutionSession
         return true;
     }
 
-    public StorageSortLockedTransferResult TryExecuteLocked(StorageSortTransfer transfer)
+    public StorageSortLockedTransferResult TryExecuteLocked(
+        StorageSortTransfer transfer,
+        StorageSortRecoveryManager recoveryManager,
+        Guid contractId,
+        Guid transferId)
     {
+        ArgumentNullException.ThrowIfNull(recoveryManager);
+        if (contractId == Guid.Empty || transferId == Guid.Empty)
+            return Failure(StorageSortLockedTransferFailure.InvalidSequence);
         if (!StorageSortTransferPolicy.IsExpectedTransfer(
                 this.RuntimePlan.Plan.Transfers,
                 this.NextSequence,
@@ -174,7 +215,7 @@ internal sealed class StorageSortExecutionSession
             return Failure(StorageSortLockedTransferFailure.SourceItemMissing);
         }
 
-        int sourceSlot = source.Items.IndexOf(sourceItem);
+        int sourceSlot = FindReferenceSlot(source, sourceItem);
         if (sourceSlot < 0)
             return Failure(StorageSortLockedTransferFailure.SourceItemMissing);
         if (GetSymmetricAcceptableCapacity(destination, sourceItem) < sourceItem.Stack)
@@ -183,6 +224,8 @@ internal sealed class StorageSortExecutionSession
         StorageSortChestFingerprint expectedSource = this.ExpectedChestFingerprints[transfer.SourceChest];
         StorageSortChestFingerprint expectedDestination =
             this.ExpectedChestFingerprints[transfer.DestinationChest];
+        string expectedSourceStackId =
+            $"{transfer.SourceChest.X}:{transfer.SourceChest.Y}:{sourceSlot}";
         List<(Item Item, int Stack)> destinationStacks = destination.Items
             .Where(item => item is not null
                 && item.canStackWith(sourceItem)
@@ -224,8 +267,8 @@ internal sealed class StorageSortExecutionSession
             int destinationAfter = destinationStacks.Sum(entry => entry.Item.Stack)
                 + (addedToDestination ? sourceItem.Stack : 0);
             if (destinationAfter - destinationBefore != originalQuantity
-                || source.Items.Contains(sourceItem)
-                || (addedToDestination && !destination.Items.Contains(sourceItem)))
+                || ContainsReference(source, sourceItem)
+                || (addedToDestination && !ContainsReference(destination, sourceItem)))
             {
                 throw new InvalidOperationException("Locked transfer failed its immediate conservation audit.");
             }
@@ -252,7 +295,9 @@ internal sealed class StorageSortExecutionSession
             return new StorageSortLockedTransferResult(
                 StorageSortLockedTransferFailure.None,
                 originalQuantity,
-                RequiresPersistentRecovery: false);
+                PersistedRecoveryItems: 0,
+                RequiresPersistentRecovery: false,
+                UnresolvedItem: null);
         }
         catch
         {
@@ -267,12 +312,22 @@ internal sealed class StorageSortExecutionSession
                 addedToDestination,
                 expectedSource,
                 expectedDestination);
-            return rolledBack
-                ? Failure(StorageSortLockedTransferFailure.CommitFailed)
-                : new StorageSortLockedTransferResult(
-                    StorageSortLockedTransferFailure.RollbackFailed,
-                    MovedItems: 0,
-                    RequiresPersistentRecovery: true);
+            if (rolledBack)
+                return Failure(StorageSortLockedTransferFailure.CommitFailed);
+
+            return this.TryPersistFailedRollback(
+                source,
+                destination,
+                sourceItem,
+                sourceSlot,
+                originalQuantity,
+                destinationStacks,
+                expectedSourceStackId,
+                expectedSource,
+                expectedDestination,
+                recoveryManager,
+                contractId,
+                transferId);
         }
     }
 
@@ -336,12 +391,12 @@ internal sealed class StorageSortExecutionSession
         try
         {
             if (addedToDestination)
-                destination.Items.Remove(sourceItem);
+                RemoveAllReferences(destination, sourceItem);
             foreach ((Item item, int stack) in destinationStacks)
                 item.Stack = stack;
 
             sourceItem.Stack = originalQuantity;
-            if (removedFromSource && !source.Items.Contains(sourceItem))
+            if (removedFromSource && !ContainsReference(source, sourceItem))
             {
                 if (sourceSlot <= source.Items.Count)
                     source.Items.Insert(sourceSlot, sourceItem);
@@ -373,12 +428,178 @@ internal sealed class StorageSortExecutionSession
         }
     }
 
+    private StorageSortLockedTransferResult TryPersistFailedRollback(
+        Chest source,
+        Chest destination,
+        Item sourceItem,
+        int sourceSlot,
+        int originalQuantity,
+        IReadOnlyList<(Item Item, int Stack)> destinationStacks,
+        string expectedSourceStackId,
+        StorageSortChestFingerprint expectedSource,
+        StorageSortChestFingerprint expectedDestination,
+        StorageSortRecoveryManager recoveryManager,
+        Guid contractId,
+        Guid transferId)
+    {
+        bool detached = TryDetachExactRecoveryItem(
+            source,
+            destination,
+            sourceItem,
+            originalQuantity,
+            destinationStacks,
+            expectedSourceStackId,
+            expectedSource,
+            expectedDestination);
+        if (detached)
+        {
+            StorageSortRecoveryWriteStatus recoveryStatus = recoveryManager.TryPersistDetached(
+                contractId,
+                transferId,
+                sourceItem);
+            if (recoveryStatus == StorageSortRecoveryWriteStatus.Persisted)
+            {
+                return new StorageSortLockedTransferResult(
+                    StorageSortLockedTransferFailure.RollbackFailed,
+                    MovedItems: 0,
+                    PersistedRecoveryItems: originalQuantity,
+                    RequiresPersistentRecovery: false,
+                    UnresolvedItem: null);
+            }
+            if (recoveryStatus == StorageSortRecoveryWriteStatus.UncertainAfterWrite)
+            {
+                return new StorageSortLockedTransferResult(
+                    StorageSortLockedTransferFailure.RollbackFailed,
+                    MovedItems: 0,
+                    PersistedRecoveryItems: 0,
+                    RequiresPersistentRecovery: true,
+                    UnresolvedItem: sourceItem);
+            }
+        }
+
+        try
+        {
+            foreach ((Item item, int stack) in destinationStacks)
+                item.Stack = stack;
+            sourceItem.Stack = originalQuantity;
+            RemoveAllReferences(destination, sourceItem);
+            if (!ContainsReference(source, sourceItem))
+            {
+                if (sourceSlot <= source.Items.Count)
+                    source.Items.Insert(sourceSlot, sourceItem);
+                else
+                    source.Items.Add(sourceItem);
+            }
+        }
+        catch
+        {
+            return new StorageSortLockedTransferResult(
+                StorageSortLockedTransferFailure.RollbackFailed,
+                MovedItems: 0,
+                PersistedRecoveryItems: 0,
+                RequiresPersistentRecovery: true,
+                UnresolvedItem: sourceItem);
+        }
+
+        bool exactSourceRestored = IsExactFingerprint(expectedSource, source);
+        bool exactDestinationRestored = IsExactFingerprint(expectedDestination, destination);
+        return exactSourceRestored && exactDestinationRestored
+            ? Failure(StorageSortLockedTransferFailure.CommitFailed)
+            : new StorageSortLockedTransferResult(
+                StorageSortLockedTransferFailure.RollbackFailed,
+                MovedItems: 0,
+                PersistedRecoveryItems: 0,
+                RequiresPersistentRecovery: true,
+                UnresolvedItem: sourceItem);
+    }
+
+    private static bool TryDetachExactRecoveryItem(
+        Chest source,
+        Chest destination,
+        Item sourceItem,
+        int originalQuantity,
+        IReadOnlyList<(Item Item, int Stack)> destinationStacks,
+        string expectedSourceStackId,
+        StorageSortChestFingerprint expectedSource,
+        StorageSortChestFingerprint expectedDestination)
+    {
+        try
+        {
+            RemoveAllReferences(source, sourceItem);
+            RemoveAllReferences(destination, sourceItem);
+            foreach ((Item item, int stack) in destinationStacks)
+                item.Stack = stack;
+            sourceItem.Stack = originalQuantity;
+
+            return IsExactFingerprint(expectedDestination, destination)
+                && IsSourceFingerprintWithoutTransfer(
+                    expectedSourceStackId,
+                    expectedSource,
+                    source);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsSourceFingerprintWithoutTransfer(
+        string stackId,
+        StorageSortChestFingerprint expected,
+        Chest source)
+    {
+        if (!TryCreateFingerprint(expected.ChestTile, source, out StorageSortChestFingerprint? actual)
+            || actual is null)
+        {
+            return false;
+        }
+
+        return StorageSortRecoveryValidation.IsSourceWithoutTransfer(
+            stackId,
+            expected,
+            actual);
+    }
+
+    private static bool IsExactFingerprint(StorageSortChestFingerprint expected, Chest chest)
+    {
+        return TryCreateFingerprint(expected.ChestTile, chest, out StorageSortChestFingerprint? actual)
+            && actual is not null
+            && StorageSortSnapshotValidation.IsChestUnchanged(expected, actual);
+    }
+
+    private static void RemoveAllReferences(Chest chest, Item item)
+    {
+        for (int index = chest.Items.Count - 1; index >= 0; index--)
+        {
+            if (ReferenceEquals(chest.Items[index], item))
+                chest.Items.RemoveAt(index);
+        }
+    }
+
+    private static bool ContainsReference(Chest chest, Item item)
+    {
+        return FindReferenceSlot(chest, item) >= 0;
+    }
+
+    private static int FindReferenceSlot(Chest chest, Item item)
+    {
+        for (int index = 0; index < chest.Items.Count; index++)
+        {
+            if (ReferenceEquals(chest.Items[index], item))
+                return index;
+        }
+
+        return -1;
+    }
+
     private static StorageSortLockedTransferResult Failure(
         StorageSortLockedTransferFailure failure)
     {
         return new StorageSortLockedTransferResult(
             failure,
             MovedItems: 0,
-            RequiresPersistentRecovery: false);
+            PersistedRecoveryItems: 0,
+            RequiresPersistentRecovery: false,
+            UnresolvedItem: null);
     }
 }

--- a/StorageSortRecoveryManager.cs
+++ b/StorageSortRecoveryManager.cs
@@ -1,0 +1,374 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Xml;
+using System.Xml.Serialization;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Inventories;
+using StardewValley.Network;
+
+namespace EvilFarmOwner;
+
+internal enum StorageSortRecoveryWriteStatus
+{
+    RejectedBeforeWrite,
+    Persisted,
+    UncertainAfterWrite
+}
+
+internal sealed class StorageSortRecoveryManager
+{
+    internal const string RecoveryDataKey = "Aveouter.EvilFarmOwner/StorageSortRecovery";
+    internal const string RecoveryTransferDataKey =
+        "Aveouter.EvilFarmOwner/StorageSortRecoveryTransfer";
+
+    private const int RetryIntervalTicks = 60;
+
+    private readonly IMonitor Monitor;
+    private int RetryTicks;
+
+    public StorageSortRecoveryManager(IMonitor monitor)
+    {
+        this.Monitor = monitor;
+    }
+
+    public bool HasPendingRecovery { get; private set; }
+
+    public void OnSaveLoaded()
+    {
+        this.HasPendingRecovery = false;
+        this.RetryTicks = 0;
+        if (Context.IsWorldReady && Context.IsMainPlayer)
+            this.TryRestore();
+    }
+
+    public void Update()
+    {
+        if (!Context.IsWorldReady
+            || !Context.IsMainPlayer
+            || !this.HasPendingRecovery
+            || ++this.RetryTicks % RetryIntervalTicks != 0)
+        {
+            return;
+        }
+
+        this.TryRestore();
+    }
+
+    public void OnReturnedToTitle()
+    {
+        this.HasPendingRecovery = false;
+        this.RetryTicks = 0;
+    }
+
+    public bool TryRecover()
+    {
+        return this.TryRestore();
+    }
+
+    public StorageSortRecoveryWriteStatus TryPersistDetached(
+        Guid contractId,
+        Guid transferId,
+        Item detachedItem)
+    {
+        if (!Context.IsWorldReady
+            || !Context.IsMainPlayer
+            || contractId == Guid.Empty
+            || transferId == Guid.Empty
+            || detachedItem.Stack <= 0)
+            return StorageSortRecoveryWriteStatus.RejectedBeforeWrite;
+
+        bool writeAttempted = false;
+        try
+        {
+            HarvestCargoRecoveryItemData savedItem = CreateRecoveryItem(transferId, detachedItem);
+            HarvestCargoRecoverySaveData state = HarvestCargoRecoveryState.Create(
+                Game1.uniqueIDForThisGame,
+                contractId.ToString("N"),
+                new[] { savedItem });
+            if (!HarvestCargoRecoveryState.IsValid(state, Game1.uniqueIDForThisGame))
+                return StorageSortRecoveryWriteStatus.RejectedBeforeWrite;
+
+            string serialized = JsonSerializer.Serialize(state);
+            if (!HarvestCargoRecoveryState.IsSerializedPayloadValid(serialized))
+                return StorageSortRecoveryWriteStatus.RejectedBeforeWrite;
+            if (Game1.MasterPlayer.modData.TryGetValue(RecoveryDataKey, out string? prior)
+                && !string.IsNullOrWhiteSpace(prior)
+                && !string.Equals(prior, serialized, StringComparison.Ordinal))
+            {
+                this.HasPendingRecovery = true;
+                this.Monitor.Log(
+                    "Refusing to overwrite a different unresolved storage-sort recovery record.",
+                    LogLevel.Error);
+                return StorageSortRecoveryWriteStatus.RejectedBeforeWrite;
+            }
+
+            writeAttempted = true;
+            Game1.MasterPlayer.modData[RecoveryDataKey] = serialized;
+            bool verified = Game1.MasterPlayer.modData.TryGetValue(
+                    RecoveryDataKey,
+                    out string? written)
+                && string.Equals(written, serialized, StringComparison.Ordinal);
+            this.HasPendingRecovery = true;
+            this.RetryTicks = 0;
+            if (verified)
+            {
+                this.Monitor.Log(
+                    $"Persisted storage-sort transfer {transferId:N} x{detachedItem.Stack} "
+                    + "into the shared emergency-quarantine recovery record.",
+                    LogLevel.Error);
+            }
+
+            return verified
+                ? StorageSortRecoveryWriteStatus.Persisted
+                : StorageSortRecoveryWriteStatus.UncertainAfterWrite;
+        }
+        catch (Exception ex)
+        {
+            this.HasPendingRecovery = writeAttempted || HasStoredRecoveryRecord();
+            this.Monitor.Log(
+                $"CRITICAL: storage-sort recovery record write failed: {ex}",
+                LogLevel.Error);
+            return writeAttempted
+                ? StorageSortRecoveryWriteStatus.UncertainAfterWrite
+                : StorageSortRecoveryWriteStatus.RejectedBeforeWrite;
+        }
+    }
+
+    private bool TryRestore()
+    {
+        if (!Context.IsWorldReady || !Context.IsMainPlayer)
+            return false;
+        if (!Game1.MasterPlayer.modData.TryGetValue(RecoveryDataKey, out string? serialized)
+            || string.IsNullOrWhiteSpace(serialized))
+        {
+            this.HasPendingRecovery = false;
+            this.RetryTicks = 0;
+            return true;
+        }
+
+        this.HasPendingRecovery = true;
+        NetMutex mutex = Game1.player.team.GetOrCreateGlobalInventoryMutex(
+            HarvestingContractExecutionController.QuarantineInventoryId);
+        try
+        {
+            if (!HarvestCargoRecoveryState.IsSerializedPayloadValid(serialized))
+                throw new InvalidDataException("Storage-sort recovery payload exceeds its safe limit.");
+
+            HarvestCargoRecoverySaveData? state =
+                JsonSerializer.Deserialize<HarvestCargoRecoverySaveData>(serialized);
+            if (!HarvestCargoRecoveryState.IsValid(state, Game1.uniqueIDForThisGame)
+                || state is null
+                || state.Items.Length != 1)
+            {
+                throw new InvalidDataException(
+                    "Storage-sort recovery payload failed schema, save, or item validation.");
+            }
+            if (!TryAcquireImmediately(mutex))
+                return false;
+
+            HarvestCargoRecoveryItemData saved = state.Items[0];
+            Inventory quarantine = Game1.player.team.GetOrCreateGlobalInventory(
+                HarvestingContractExecutionController.QuarantineInventoryId);
+            Item? existing = quarantine.FirstOrDefault(item => item is not null
+                && item.modData.TryGetValue(
+                    RecoveryTransferDataKey,
+                    out string? transferId)
+                && string.Equals(transferId, saved.TransferId, StringComparison.Ordinal));
+            if (existing is not null)
+            {
+                if (!MatchesSavedItem(existing, saved, ignoreRecoveryTag: true))
+                {
+                    throw new InvalidDataException(
+                        $"Storage-sort recovery transfer {saved.TransferId} identifies different cargo.");
+                }
+            }
+            else
+            {
+                Item restored = DeserializeRecoveryItem(saved);
+                if (!MatchesSavedItem(restored, saved, ignoreRecoveryTag: false))
+                {
+                    throw new InvalidDataException(
+                        $"Storage-sort transfer {saved.TransferId} could not be reconstructed exactly.");
+                }
+
+                restored.modData[
+                    RecoveryTransferDataKey] = saved.TransferId;
+                quarantine.Add(restored);
+                if (!quarantine.Any(item => ReferenceEquals(item, restored)))
+                {
+                    throw new InvalidDataException(
+                        $"Quarantine did not retain storage-sort transfer {saved.TransferId}.");
+                }
+            }
+
+            Game1.MasterPlayer.modData.Remove(RecoveryDataKey);
+            if (Game1.MasterPlayer.modData.TryGetValue(
+                    RecoveryDataKey,
+                    out string? remaining)
+                && !string.IsNullOrWhiteSpace(remaining))
+            {
+                throw new IOException("Storage-sort recovery record could not be cleared after restore.");
+            }
+            this.HasPendingRecovery = false;
+            this.RetryTicks = 0;
+            this.Monitor.Log(
+                $"Restored storage-sort transfer {saved.TransferId} into the shared emergency quarantine.",
+                LogLevel.Warn);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            this.Monitor.Log(
+                $"Storage-sort recovery remains fail-closed: {ex}",
+                LogLevel.Error);
+            return false;
+        }
+        finally
+        {
+            if (mutex.IsLockHeld())
+                mutex.ReleaseLock();
+        }
+    }
+
+    private static HarvestCargoRecoveryItemData CreateRecoveryItem(Guid transferId, Item item)
+    {
+        Type type = item.GetType();
+        return new HarvestCargoRecoveryItemData
+        {
+            TransferId = transferId.ToString("N"),
+            QualifiedItemId = item.QualifiedItemId,
+            DisplayName = item.DisplayName,
+            RuntimeType = type.FullName ?? type.Name,
+            RuntimeAssembly = type.Assembly.GetName().Name ?? "",
+            SerializedItemXml = SerializeItem(item),
+            Quality = item.Quality,
+            Stack = item.Stack,
+            ModData = item.modData.Pairs
+                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
+        };
+    }
+
+    private static bool MatchesSavedItem(
+        Item item,
+        HarvestCargoRecoveryItemData saved,
+        bool ignoreRecoveryTag)
+    {
+        Type type = item.GetType();
+        if (!string.Equals(item.QualifiedItemId, saved.QualifiedItemId, StringComparison.Ordinal)
+            || !string.Equals(type.FullName ?? type.Name, saved.RuntimeType, StringComparison.Ordinal)
+            || !string.Equals(
+                type.Assembly.GetName().Name,
+                saved.RuntimeAssembly,
+                StringComparison.Ordinal)
+            || item.Quality != saved.Quality
+            || item.Stack != saved.Stack)
+        {
+            return false;
+        }
+
+        Dictionary<string, string> actualModData = item.modData.Pairs
+            .Where(pair => !ignoreRecoveryTag
+                || !string.Equals(
+                    pair.Key,
+                    RecoveryTransferDataKey,
+                    StringComparison.Ordinal))
+            .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
+        bool modDataMatches = actualModData.Count == saved.ModData.Count
+            && saved.ModData.All(pair => actualModData.TryGetValue(pair.Key, out string? value)
+                && string.Equals(value, pair.Value, StringComparison.Ordinal));
+        if (!modDataMatches)
+            return false;
+
+        string? recoveryTag = null;
+        if (ignoreRecoveryTag)
+        {
+            item.modData.TryGetValue(
+                RecoveryTransferDataKey,
+                out recoveryTag);
+            item.modData.Remove(RecoveryTransferDataKey);
+        }
+
+        try
+        {
+            return string.Equals(
+                SerializeItem(item),
+                saved.SerializedItemXml,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (ignoreRecoveryTag && recoveryTag is not null)
+            {
+                item.modData[
+                    RecoveryTransferDataKey] = recoveryTag;
+            }
+        }
+    }
+
+    private static string SerializeItem(Item item)
+    {
+        XmlSerializer serializer = new(item.GetType());
+        XmlSerializerNamespaces namespaces = new();
+        namespaces.Add("", "");
+        using StringWriter writer = new(CultureInfo.InvariantCulture);
+        serializer.Serialize(writer, item, namespaces);
+        return writer.ToString();
+    }
+
+    private static Item DeserializeRecoveryItem(HarvestCargoRecoveryItemData saved)
+    {
+        System.Reflection.Assembly? assembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(candidate => string.Equals(
+                candidate.GetName().Name,
+                saved.RuntimeAssembly,
+                StringComparison.Ordinal));
+        Type? itemType = assembly?.GetType(saved.RuntimeType, throwOnError: false, ignoreCase: false);
+        if (itemType is null || !typeof(Item).IsAssignableFrom(itemType))
+        {
+            throw new InvalidDataException(
+                $"Recovery item type '{saved.RuntimeType}' from '{saved.RuntimeAssembly}' is unavailable.");
+        }
+
+        XmlSerializer serializer = new(itemType);
+        XmlReaderSettings settings = new()
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null
+        };
+        using StringReader stringReader = new(saved.SerializedItemXml);
+        using XmlReader xmlReader = XmlReader.Create(stringReader, settings);
+        return serializer.Deserialize(xmlReader) as Item
+            ?? throw new InvalidDataException(
+                $"Storage-sort transfer {saved.TransferId} did not deserialize as an item.");
+    }
+
+    private static bool TryAcquireImmediately(NetMutex mutex)
+    {
+        if (mutex.IsLockHeld())
+            return true;
+        if (mutex.IsLocked())
+            return false;
+
+        bool acquired = false;
+        mutex.RequestLock(() => acquired = true, () => acquired = false);
+        if (!acquired)
+            mutex.Update(Game1.getOnlineFarmers());
+        return acquired || mutex.IsLockHeld();
+    }
+
+    private static bool HasStoredRecoveryRecord()
+    {
+        try
+        {
+            return Context.IsWorldReady
+                && Game1.MasterPlayer.modData.TryGetValue(RecoveryDataKey, out string? serialized)
+                && !string.IsNullOrWhiteSpace(serialized);
+        }
+        catch
+        {
+            return true;
+        }
+    }
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -55,6 +55,7 @@ List<(string Name, Action Test)> tests = new()
     ("storage transfer lock order", TestStorageTransferLockOrder),
     ("storage transfer sequence", TestStorageTransferSequence),
     ("storage transfer conservation", TestStorageTransferConservation),
+    ("storage transfer recovery ownership", TestStorageTransferRecoveryOwnership),
     ("harvest partial remainder", TestHarvestPartialRemainder),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
@@ -1157,6 +1158,72 @@ static void TestStorageTransferConservation()
         restoredSource: 21,
         quarantine: 0,
         unresolved: 0));
+}
+
+static void TestStorageTransferRecoveryOwnership()
+{
+    GridPoint tile = new(4, 7);
+    StorageSortItemFingerprint first = SortFingerprint("(O)24", -75, 8, "first");
+    StorageSortItemFingerprint removed = SortFingerprint("(O)190", -79, 3, "removed");
+    StorageSortItemFingerprint last = SortFingerprint("(O)378", -12, 12, "last");
+    StorageSortChestFingerprint expected = new(
+        tile,
+        Capacity: 36,
+        new StorageSortStackBinding[]
+        {
+            new("4:7:0", tile, 0, first),
+            new("4:7:1", tile, 1, removed),
+            new("4:7:2", tile, 2, last)
+        });
+    StorageSortChestFingerprint actualWithoutRemoved = new(
+        tile,
+        Capacity: 36,
+        new StorageSortStackBinding[]
+        {
+            new("4:7:0", tile, 0, first),
+            new("4:7:1", tile, 1, last)
+        });
+
+    Equal(true, StorageSortRecoveryValidation.IsSourceWithoutTransfer(
+        "4:7:1",
+        expected,
+        actualWithoutRemoved));
+    Equal(false, StorageSortRecoveryValidation.IsSourceWithoutTransfer(
+        "4:7:9",
+        expected,
+        actualWithoutRemoved));
+    Equal(false, StorageSortRecoveryValidation.IsSourceWithoutTransfer(
+        "4:7:1",
+        expected,
+        actualWithoutRemoved with { Capacity = 12 }));
+    Equal(false, StorageSortRecoveryValidation.IsSourceWithoutTransfer(
+        "4:7:1",
+        expected,
+        actualWithoutRemoved with
+        {
+            Stacks = new StorageSortStackBinding[]
+            {
+                new("4:7:0", tile, 0, first),
+                new("4:7:1", tile, 1, removed)
+            }
+        }));
+}
+
+static StorageSortItemFingerprint SortFingerprint(
+    string itemId,
+    int category,
+    int quantity,
+    string xml)
+{
+    return new StorageSortItemFingerprint(
+        itemId,
+        RuntimeType: "StardewValley.Object",
+        RuntimeAssembly: "Stardew Valley",
+        category,
+        Quality: 0,
+        quantity,
+        MaximumStackSize: 999,
+        SerializedXml: xml);
 }
 
 static StorageSortChestSnapshot SortChest(


### PR DESCRIPTION
## 变更概述

将箱子整理事务的不可验证回滚接入现有团队应急隔离仓与持久恢复记录，保证后续合同控制器不能把临时内存引用当成已安全结算。

## 修改动机

PR #56 已能精确回滚双箱写入，但 `RollbackFailed` 仅是硬信号。#7 明确要求无法验证来源恢复时，必须保留唯一物品所有权并进入持久隔离/恢复，而不是继续下一步或静默释放对象。

## 主要改动

- 回滚失败后，在仍持有双箱锁时剥离本次转移对目标栈的贡献，并验证目标恢复、来源仅缺少该转移栈。
- 只有完成上述唯一所有权验证后，才允许把精确 Item 交给持久恢复管理器。
- 复用现有团队 quarantine inventory 和受限 `HarvestCargoRecoveryState` 格式，但使用独立记录键与 transfer tag，避免覆盖收获恢复账本。
- 恢复记录写入后立即回读验证；同一记录幂等，不同未决记录拒绝覆盖。
- 将写入结果区分为“写前拒绝 / 已验证持久化 / 写后状态不确定”。写前拒绝会尝试精确放回来源箱；写后不确定则保留唯一 Item 引用并要求控制器继续 fail-closed，绝不复制回箱。
- 存档加载及后台重试会在取得共享隔离仓锁后恢复精确运行时类型、XML 与 modData，并验证 transfer ID 后清除恢复记录。
- `efo_quarantine` 打开前同时恢复收获和整理记录。
- 所有 Item 查找/删除改为引用相等，避免误删内容相同但所有权不同的另一栈。

## 实验与验证

- `dotnet format --verify-no-changes`
- `dotnet build -c Release -p:EnableModDeploy=false`：0 warning / 0 error
- `dotnet run --project tests -c Release`：73/73 passed
- `git diff --check`

## Benchmark/Baseline impact

正常成功路径仅增加参数校验，不增加逐帧工作；恢复管理器只在存在未决记录时每 60 tick 重试。500 例固定种子规划不变量仍通过。

## 风险与限制

- 该恢复路径仍未通过真实 x86_64 Stardew Item XML、NetMutex、保存/重载验收；ARM64 逻辑测试宿主无法加载游戏程序集。
- `UnresolvedItem` 仅供下一层合同控制器在“写后不确定”时保留所有权；在控制器接入并覆盖保存边界前，整理任务仍未开放到 UI。
- 本 PR 不增加 NPC 路线、工资扣款、菜单或多人消息。

Refs #7