### PR TITLE
feat(storage): preflight visible sort routes

### DIFF
--- a/StorageSortRoutePlanner.cs
+++ b/StorageSortRoutePlanner.cs
@@ -1,0 +1,324 @@
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Locations;
+
+namespace EvilFarmOwner;
+
+internal sealed record StorageSortInteractionOption(
+    GridPoint InteractionTile,
+    int Distance,
+    int OffsetPriority);
+
+internal static class StorageSortRouteSelection
+{
+    public static IEnumerable<StorageSortInteractionOption> Order(
+        IEnumerable<StorageSortInteractionOption> options)
+    {
+        return options
+            .OrderBy(option => option.Distance)
+            .ThenBy(option => option.OffsetPriority)
+            .ThenBy(option => option.InteractionTile.Y)
+            .ThenBy(option => option.InteractionTile.X);
+    }
+}
+
+internal sealed record StorageSortRouteStep(
+    StorageSortTransfer Transfer,
+    Point SourceInteractionTile,
+    Stack<Point> SourcePath,
+    Point DestinationInteractionTile,
+    Stack<Point> DestinationPath);
+
+internal sealed record StorageSortRoutePlan(
+    Point ArrivalTile,
+    FarmBoundarySide ArrivalSide,
+    IReadOnlyList<StorageSortRouteStep> Steps,
+    Stack<Point> ReturnPath);
+
+internal enum StorageSortRouteFailure
+{
+    None,
+    InvalidPlan,
+    UnsupportedFarmMap,
+    NoBoundaryEntrance,
+    NoSafeArrival,
+    NoSafeRoundTrip
+}
+
+internal sealed record StorageSortRoutePlanResult(
+    StorageSortRouteFailure Failure,
+    StorageSortRoutePlan? Plan)
+{
+    public bool IsSuccess => this.Failure == StorageSortRouteFailure.None
+        && this.Plan is not null;
+}
+
+internal sealed class StorageSortRoutePlanner
+{
+    private const int MaximumSupportedMapDimension = 255;
+    private const int MaximumArrivalPathChecksPerSide = 8;
+    private static readonly Point[] InteractionOffsets =
+    {
+        new(0, 1),
+        new(-1, 0),
+        new(1, 0),
+        new(0, -1)
+    };
+
+    private readonly IMonitor Monitor;
+
+    public StorageSortRoutePlanner(IMonitor monitor)
+    {
+        this.Monitor = monitor;
+    }
+
+    public StorageSortRoutePlanResult TryCreate(
+        Farm farm,
+        NPC worker,
+        StorageSortRuntimePlan runtimePlan)
+    {
+        if (runtimePlan.Plan.Transfers.Count == 0)
+        {
+            return new StorageSortRoutePlanResult(
+                StorageSortRouteFailure.InvalidPlan,
+                Plan: null);
+        }
+
+        int mapWidth = farm.Map.Layers[0].LayerWidth;
+        int mapHeight = farm.Map.Layers[0].LayerHeight;
+        if (mapWidth > MaximumSupportedMapDimension || mapHeight > MaximumSupportedMapDimension)
+        {
+            return new StorageSortRoutePlanResult(
+                StorageSortRouteFailure.UnsupportedFarmMap,
+                Plan: null);
+        }
+
+        IReadOnlyList<GridPoint> arrivals = FarmEntranceSelection.OrderBoundaryArrivalCandidates(
+            mapWidth,
+            mapHeight,
+            farm.warps.Select(warp => new GridPoint(warp.X, warp.Y)));
+        if (arrivals.Count == 0)
+        {
+            return new StorageSortRoutePlanResult(
+                StorageSortRouteFailure.NoBoundaryEntrance,
+                Plan: null);
+        }
+
+        bool foundSafeArrival = false;
+        Dictionary<FarmBoundarySide, int> checkedPathsBySide = new();
+        Dictionary<GridPoint, GridRouteMap> routeCache = new();
+        foreach (GridPoint arrival in arrivals)
+        {
+            FarmBoundarySide arrivalSide = FarmEntranceSelection.GetNearestBoundarySide(
+                mapWidth,
+                mapHeight,
+                arrival);
+            int checkedOnSide = checkedPathsBySide.GetValueOrDefault(arrivalSide);
+            if (checkedOnSide >= MaximumArrivalPathChecksPerSide)
+                continue;
+
+            Vector2 arrivalVector = new(arrival.X, arrival.Y);
+            if (farm.warps.Any(warp => warp.X == arrival.X && warp.Y == arrival.Y)
+                || farm.doors.ContainsKey(new Point(arrival.X, arrival.Y))
+                || !farm.CanSpawnCharacterHere(arrivalVector))
+            {
+                continue;
+            }
+
+            foundSafeArrival = true;
+            checkedPathsBySide[arrivalSide] = checkedOnSide + 1;
+            if (!this.TryCreateFromArrival(
+                    farm,
+                    worker,
+                    runtimePlan.Plan.Transfers,
+                    arrival,
+                    routeCache,
+                    out StorageSortRoutePlan? routePlan)
+                || routePlan is null)
+            {
+                continue;
+            }
+
+            return new StorageSortRoutePlanResult(StorageSortRouteFailure.None, routePlan);
+        }
+
+        return new StorageSortRoutePlanResult(
+            foundSafeArrival
+                ? StorageSortRouteFailure.NoSafeRoundTrip
+                : StorageSortRouteFailure.NoSafeArrival,
+            Plan: null);
+    }
+
+    private bool TryCreateFromArrival(
+        Farm farm,
+        NPC worker,
+        IReadOnlyList<StorageSortTransfer> transfers,
+        GridPoint arrival,
+        Dictionary<GridPoint, GridRouteMap> routeCache,
+        out StorageSortRoutePlan? plan)
+    {
+        plan = null;
+        GridPoint current = arrival;
+        List<StorageSortRouteStep> steps = new(transfers.Count);
+        foreach (StorageSortTransfer transfer in transfers)
+        {
+            if (!this.TryCreateChestRoute(
+                    farm,
+                    worker,
+                    current,
+                    transfer.SourceChest,
+                    routeCache,
+                    out GridPoint sourceInteraction,
+                    out Stack<Point>? sourcePath)
+                || sourcePath is null
+                || !this.TryCreateChestRoute(
+                    farm,
+                    worker,
+                    sourceInteraction,
+                    transfer.DestinationChest,
+                    routeCache,
+                    out GridPoint destinationInteraction,
+                    out Stack<Point>? destinationPath)
+                || destinationPath is null)
+            {
+                return false;
+            }
+
+            steps.Add(new StorageSortRouteStep(
+                transfer,
+                new Point(sourceInteraction.X, sourceInteraction.Y),
+                sourcePath,
+                new Point(destinationInteraction.X, destinationInteraction.Y),
+                destinationPath));
+            current = destinationInteraction;
+        }
+
+        if (!this.TryCreateDirectRoute(
+                farm,
+                worker,
+                current,
+                arrival,
+                routeCache,
+                out Stack<Point>? returnPath)
+            || returnPath is null)
+        {
+            return false;
+        }
+
+        plan = new StorageSortRoutePlan(
+            new Point(arrival.X, arrival.Y),
+            FarmEntranceSelection.GetNearestBoundarySide(
+                farm.Map.Layers[0].LayerWidth,
+                farm.Map.Layers[0].LayerHeight,
+                arrival),
+            steps,
+            returnPath);
+        return true;
+    }
+
+    private bool TryCreateChestRoute(
+        Farm farm,
+        NPC worker,
+        GridPoint start,
+        GridPoint chestTile,
+        Dictionary<GridPoint, GridRouteMap> routeCache,
+        out GridPoint interaction,
+        out Stack<Point>? path)
+    {
+        interaction = default;
+        path = null;
+        if (!this.TryGetRoutes(farm, worker, start, routeCache, out GridRouteMap? routes)
+            || routes is null)
+        {
+            return false;
+        }
+
+        List<StorageSortInteractionOption> options = new();
+        for (int index = 0; index < InteractionOffsets.Length; index++)
+        {
+            Point offset = InteractionOffsets[index];
+            GridPoint candidate = new(chestTile.X + offset.X, chestTile.Y + offset.Y);
+            if (routes.TryGetDistance(candidate, out int distance))
+                options.Add(new StorageSortInteractionOption(candidate, distance, index));
+        }
+
+        foreach (StorageSortInteractionOption option in StorageSortRouteSelection.Order(options))
+        {
+            if (!routes.TryGetPath(option.InteractionTile, out IReadOnlyList<GridPoint> gridPath))
+                continue;
+
+            Stack<Point> candidatePath = FarmNavigationMap.ToPath(gridPath);
+            if (!FarmNavigationMap.CanBeginPath(
+                    farm,
+                    worker,
+                    new Point(start.X, start.Y),
+                    candidatePath,
+                    out _))
+            {
+                continue;
+            }
+
+            interaction = option.InteractionTile;
+            path = candidatePath;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryCreateDirectRoute(
+        Farm farm,
+        NPC worker,
+        GridPoint start,
+        GridPoint destination,
+        Dictionary<GridPoint, GridRouteMap> routeCache,
+        out Stack<Point>? path)
+    {
+        path = null;
+        if (!this.TryGetRoutes(farm, worker, start, routeCache, out GridRouteMap? routes)
+            || routes is null
+            || !routes.TryGetPath(destination, out IReadOnlyList<GridPoint> gridPath))
+        {
+            return false;
+        }
+
+        Stack<Point> candidatePath = FarmNavigationMap.ToPath(gridPath);
+        if (!FarmNavigationMap.CanBeginPath(
+                farm,
+                worker,
+                new Point(start.X, start.Y),
+                candidatePath,
+                out _))
+        {
+            return false;
+        }
+
+        path = candidatePath;
+        return true;
+    }
+
+    private bool TryGetRoutes(
+        Farm farm,
+        NPC worker,
+        GridPoint start,
+        Dictionary<GridPoint, GridRouteMap> routeCache,
+        out GridRouteMap? routes)
+    {
+        if (routeCache.TryGetValue(start, out routes))
+            return true;
+        if (!FarmNavigationMap.TryBuild(
+                farm,
+                worker,
+                new Point(start.X, start.Y),
+                this.Monitor,
+                out routes)
+            || routes is null)
+        {
+            return false;
+        }
+
+        routeCache[start] = routes;
+        return true;
+    }
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -56,6 +56,7 @@ List<(string Name, Action Test)> tests = new()
     ("storage transfer sequence", TestStorageTransferSequence),
     ("storage transfer conservation", TestStorageTransferConservation),
     ("storage transfer recovery ownership", TestStorageTransferRecoveryOwnership),
+    ("storage sort interaction ordering", TestStorageSortInteractionOrdering),
     ("harvest partial remainder", TestHarvestPartialRemainder),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
@@ -1224,6 +1225,22 @@ static StorageSortItemFingerprint SortFingerprint(
         quantity,
         MaximumStackSize: 999,
         SerializedXml: xml);
+}
+
+static void TestStorageSortInteractionOrdering()
+{
+    StorageSortInteractionOption[] options =
+    {
+        new(new GridPoint(5, 4), Distance: 9, OffsetPriority: 0),
+        new(new GridPoint(4, 5), Distance: 3, OffsetPriority: 2),
+        new(new GridPoint(6, 5), Distance: 3, OffsetPriority: 1),
+        new(new GridPoint(5, 6), Distance: 3, OffsetPriority: 1)
+    };
+
+    Equal(
+        "6,5|5,6|4,5|5,4",
+        string.Join("|", StorageSortRouteSelection.Order(options)
+            .Select(option => $"{option.InteractionTile.X},{option.InteractionTile.Y}")));
 }
 
 static StorageSortChestSnapshot SortChest(


### PR DESCRIPTION
## 变更概述

为 #7 增加完整的可见 NPC 路线预检：从既有优先农场边界入口出发，依次访问每次转移的来源箱、目标箱，并验证最终能安全返回同一入口。

## 修改动机

物品规划成功不代表 NPC 能安全完成合同。工资与 NPC 租约只能在所有箱子转移和完整往返路线都预检成功后才允许变更。

## 主要改动

- 继续沿用 east/right 优先、其他真实边界入口稳定回退的规则。
- 排除 warp、door 和不可生成 NPC 的到达格；每侧最多检查 8 个安全候选，支持的农场尺寸与现有浇水/收获规划一致。
- 对每个 transfer 依次选择来源箱和目标箱的可达相邻交互格，按实际最短距离、稳定偏移优先级及坐标排序。
- 预计算每段非破坏性路径以及最后返回路径；任一段不可达则整份合同预检失败。
- 按起点缓存单源路由图，多个转移/入口候选不会为同一起点重复全图扫描。
- 增加交互格稳定排序测试。

## 实验与验证

- `dotnet format --verify-no-changes`
- `dotnet build -c Release -p:EnableModDeploy=false`：0 warning / 0 error
- `dotnet run --project tests -c Release`：74/74 passed
- `git diff --check`

## Benchmark/Baseline impact

路由只在合同确认预检时执行；同一起点的 BFS 结果缓存。未增加逐帧扫描，规划固定种子不变量继续通过。

## 风险与限制

- 路线使用确认时的静态碰撞快照；执行期间若玩家改变箱子或障碍，后续控制器仍必须停止并安全退款。
- 该 PR 不创建 NPC、扣款、取锁或开放 UI。
- 自定义超大农场地图（任一维度 >255）继续 fail closed。

Refs #7