### PR TITLE
test(multiplayer): add exact request replay harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Delivered each complete harvest stack to the original requesting player first when they are online, on the same main farm, and have enough inventory capacity; otherwise retained deterministic classified-chest routing.
 - Added an acceptance-only ordinary-storage rejection fault so overflow, visible-drop, quarantine, and recovery-record safety can be tested without manually filling every chest and player slot.
 - Added an acceptance-only five-chest sorting fixture which proves exact-stack, same-item, same-category, empty fallback, conservation, and second-run idempotence on a disposable save.
+- Added a compile-gated multiplayer acceptance command that replays the farmhand's last exact request ID through the ordinary host-authoritative message path after host restart.
 - Kept recurring automatic chest sorting disabled until the manual contract passes live acceptance.
 
 ## 0.1.0-beta.1 - 2026-08-24

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -9,6 +9,7 @@
     <Nullable>enable</Nullable>
     <EnableAcceptanceFaults Condition="'$(EnableAcceptanceFaults)' == ''">false</EnableAcceptanceFaults>
     <EnableStorageSortAcceptance Condition="'$(EnableStorageSortAcceptance)' == ''">false</EnableStorageSortAcceptance>
+    <EnableMultiplayerAcceptance Condition="'$(EnableMultiplayerAcceptance)' == ''">false</EnableMultiplayerAcceptance>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EnableAcceptanceFaults)' == 'true'">
@@ -17,6 +18,10 @@
 
   <PropertyGroup Condition="'$(EnableStorageSortAcceptance)' == 'true'">
     <DefineConstants>$(DefineConstants);EFO_STORAGE_SORT_ACCEPTANCE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(EnableMultiplayerAcceptance)' == 'true'">
+    <DefineConstants>$(DefineConstants);EFO_MULTIPLAYER_ACCEPTANCE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -96,6 +96,15 @@ public sealed class ModEntry : Mod
             "ACCEPTANCE TEST BUILD: chest-sorting fixture setup is enabled. Use only on a disposable save.",
             LogLevel.Alert);
 #endif
+#if EFO_MULTIPLAYER_ACCEPTANCE
+        helper.ConsoleCommands.Add(
+            "efo_multiplayer_acceptance",
+            "Inspect or replay the last exact farmhand contract request. Excluded from production builds.",
+            this.HandleMultiplayerAcceptanceCommand);
+        this.Monitor.Log(
+            "ACCEPTANCE TEST BUILD: multiplayer request replay is enabled. Do not distribute this DLL.",
+            LogLevel.Alert);
+#endif
     }
 
 #if EFO_STORAGE_SORT_ACCEPTANCE
@@ -200,6 +209,35 @@ public sealed class ModEntry : Mod
             this.AcceptanceFaults.Arm(fault);
 
         this.Monitor.Log($"Acceptance faults armed: {this.AcceptanceFaults.Describe()}.", LogLevel.Alert);
+    }
+#endif
+
+#if EFO_MULTIPLAYER_ACCEPTANCE
+    private void HandleMultiplayerAcceptanceCommand(string command, string[] args)
+    {
+        if (args.Length == 0 || string.Equals(args[0], "status", StringComparison.OrdinalIgnoreCase))
+        {
+            this.Monitor.Log(
+                this.MultiplayerContracts?.GetAcceptanceReplayStatus()
+                    ?? "Multiplayer acceptance coordinator is unavailable.",
+                LogLevel.Info);
+            return;
+        }
+
+        if (string.Equals(args[0], "replay", StringComparison.OrdinalIgnoreCase))
+        {
+            if (this.MultiplayerContracts?.TryReplayLastAcceptanceRequest() == true)
+                return;
+
+            this.Monitor.Log(
+                "Replay requires a connected farmhand, no pending request, and one prior request from this player.",
+                LogLevel.Warn);
+            return;
+        }
+
+        this.Monitor.Log(
+            "Usage: efo_multiplayer_acceptance <status|replay>",
+            LogLevel.Info);
     }
 #endif
 

--- a/MultiplayerAcceptanceReplayBuffer.cs
+++ b/MultiplayerAcceptanceReplayBuffer.cs
@@ -1,0 +1,45 @@
+namespace EvilFarmOwner;
+
+internal sealed class MultiplayerAcceptanceReplayBuffer
+{
+    private ContractStartRequestMessage? LastRequest;
+
+    public bool HasRequest => this.LastRequest is not null;
+
+    public string RequestId => this.LastRequest?.RequestId ?? "none";
+
+    public void Capture(ContractStartRequestMessage request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        this.LastRequest = Clone(request);
+    }
+
+    public bool TryCreateReplay(long requestingPlayerId, out ContractStartRequestMessage? request)
+    {
+        request = null;
+        if (this.LastRequest is null
+            || requestingPlayerId <= 0
+            || this.LastRequest.RequestingPlayerId != requestingPlayerId)
+        {
+            return false;
+        }
+
+        request = Clone(this.LastRequest);
+        return true;
+    }
+
+    private static ContractStartRequestMessage Clone(ContractStartRequestMessage request)
+    {
+        return new ContractStartRequestMessage
+        {
+            SchemaVersion = request.SchemaVersion,
+            ModVersion = request.ModVersion,
+            SaveId = request.SaveId,
+            TotalDays = request.TotalDays,
+            RequestId = request.RequestId,
+            RequestingPlayerId = request.RequestingPlayerId,
+            WorkerName = request.WorkerName,
+            Task = request.Task
+        };
+    }
+}

--- a/MultiplayerContractCoordinator.cs
+++ b/MultiplayerContractCoordinator.cs
@@ -27,6 +27,9 @@ internal sealed class MultiplayerContractCoordinator
     private readonly Queue<string> HostSequenceOrder = new();
     private readonly HashSet<string> SeenClientResponses = new(StringComparer.Ordinal);
     private readonly Queue<string> ClientResponseOrder = new();
+#if EFO_MULTIPLAYER_ACCEPTANCE
+    private readonly MultiplayerAcceptanceReplayBuffer AcceptanceReplay = new();
+#endif
 
     private string HostSessionId = "";
     private long HostOrder;
@@ -116,6 +119,9 @@ internal sealed class MultiplayerContractCoordinator
             WorkerName = workerInternalName,
             Task = task
         };
+#if EFO_MULTIPLAYER_ACCEPTANCE
+        this.AcceptanceReplay.Capture(request);
+#endif
 
         if (Context.IsMainPlayer)
         {
@@ -144,6 +150,49 @@ internal sealed class MultiplayerContractCoordinator
             HUDMessage.newQuest_type));
         return true;
     }
+
+#if EFO_MULTIPLAYER_ACCEPTANCE
+    public string GetAcceptanceReplayStatus()
+    {
+        return $"Multiplayer acceptance replay: available={this.AcceptanceReplay.HasRequest}, "
+            + $"requestId={this.AcceptanceReplay.RequestId}.";
+    }
+
+    public bool TryReplayLastAcceptanceRequest()
+    {
+        if (!Context.IsWorldReady
+            || Context.IsMainPlayer
+            || !Context.IsMultiplayer
+            || this.PendingRequest is not null
+            || !this.AcceptanceReplay.TryCreateReplay(
+                Game1.player.UniqueMultiplayerID,
+                out ContractStartRequestMessage? request)
+            || request is null)
+        {
+            return false;
+        }
+
+        this.PendingRequest = request;
+        this.PendingTicks = 0;
+        if (this.ClientHostSession.HasSession)
+        {
+            this.SendMessage(
+                request,
+                MultiplayerContractProtocol.StartRequestType,
+                Game1.MasterPlayer.UniqueMultiplayerID);
+        }
+        else
+        {
+            this.SendSyncRequest();
+        }
+
+        this.Monitor.Log(
+            $"Acceptance replay sent exact request {request.RequestId} for "
+            + $"worker '{request.WorkerName}' and task {request.Task}.",
+            LogLevel.Alert);
+        return true;
+    }
+#endif
 
     public void OnSaveLoaded()
     {

--- a/docs/MULTIPLAYER_TEST_PLAN.md
+++ b/docs/MULTIPLAYER_TEST_PLAN.md
@@ -7,9 +7,25 @@ This is the release-gate procedure for Issue #33. Split-screen alone is not acce
 - Use two independent Stardew Valley processes connected as a real host and farmhand, preferably on two computers.
 - Install the exact same Evil Farm Owner build on both peers and compare the SHA-256 hash of `EvilFarmOwner.dll`.
 - Use Stardew Valley 1.6.15 or later in the supported 1.6 line and SMAPI 4.0 or later.
-- Use a disposable co-op save with both players on the main farm, at least one currently available adult NPC, several dry crops, several mature crops including a trellis crop when possible, placed machines that force a detour, and enough money on each player for the displayed six-hour reservation.
+- Use a disposable co-op save with one unclaimed cabin and two distinct player IDs. Put both players on the main farm with at least one currently available adult NPC, several dry crops, several mature crops including a trellis crop when possible, placed machines that force a detour, and enough money on each player for the displayed six-hour reservation.
 - Place ordinary player chests on the main farm: one with a compatible partial stack, one with the same item at another quality, one with the same category, and one nearly full fallback chest.
 - Keep both SMAPI consoles visible and retain both logs.
+
+Build the temporary acceptance-only DLL on the exact reviewed source tree, then
+install that same DLL on both peers:
+
+```sh
+dotnet build EvilFarmOwner.csproj -t:Rebuild -c Release \
+  -p:EnableAcceptanceFaults=true \
+  -p:EnableMultiplayerAcceptance=true \
+  -p:EnableModDeploy=true \
+  -p:EnableModZip=false
+```
+
+Both consoles must print the two `ACCEPTANCE TEST BUILD` alerts. The temporary
+`efo_multiplayer_acceptance` command stores the last request created by that
+farmhand process and can resend an exact copy through the ordinary SMAPI message
+path. It does not bypass host validation or invoke a controller locally.
 
 Run `efo_netstatus` on each peer before every scenario. The host must report `role=host`; the farmhand must report `role=farmhand`; both must converge on the same non-empty session and active contract ID after acceptance.
 
@@ -67,8 +83,8 @@ The host diagnostic must also report `recoveryHealthy=True` and `quarantineHealt
 ### 6. Host save and restart replay safety
 
 1. Complete a farmhand watering, harvest, or chest-sorting contract, record its request/contract result, then let the host save normally.
-2. Quit and restart the host process, reconnect the same farmhand, and verify `efo_netstatus` shows a new host session with `recoveryHealthy=True` and a nonzero processed count.
-3. Resend the exact saved request ID from the farmhand test harness. Verify the host returns the prior accepted response/result rebound to the new session, with no new lease, crop mutation, item transfer, charge, or refund.
+2. Quit and restart only the host process. Keep the farmhand game process open, reconnect that same farmhand, and verify `efo_netstatus` shows a new host session with `recoveryHealthy=True` and a nonzero processed count.
+3. On the farmhand, run `efo_multiplayer_acceptance status`, record the request ID, then run `efo_multiplayer_acceptance replay`. Verify the host returns the prior accepted response/result rebound to the new session, with no new lease, crop mutation, item transfer, charge, or refund.
 4. Repeat with a previously rejected request and verify it remains rejected without reevaluating into a new contract.
 5. In a disposable copy, corrupt or schema-mismatch the persisted recovery record. Include a duplicate transfer ID and a produced-item total which does not equal requester inventory plus chest, overflow, and visible-drop totals. Verify the host reports `recoveryHealthy=False` and rejects all new contracts without mutating money or world state.
 6. In disposable copies created by the protocol-3 through protocol-6 development builds, retain a clean recovery ledger and load it with protocol 7. Verify the host validates and rebinds each prior response/result to the new session, reports `recoveryHealthy=True`, and an exact request replay causes no second contract, mutation, transfer, charge, or refund. A mixed or older-than-3 schema must still fail closed.
@@ -95,3 +111,8 @@ The multiplayer gate passes only when:
 - disconnect/reconnect produces one contract, one mutation, and one settlement;
 - host save/restart plus exact request replay produces no second contract, mutation, transfer, charge, or refund;
 - the tested DLL SHA-256 and mod version are recorded in the Issue #33 or PR comment.
+
+After the matrix, rebuild and deploy the ordinary production DLL with both
+acceptance switches explicitly disabled, run `./scripts/verify-release.sh`, and
+scan the deployed DLL to confirm neither `efo_acceptance_faults` nor
+`efo_multiplayer_acceptance` is present before packaging or release smoke tests.

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -36,6 +36,7 @@ dotnet run \
   --project tests/EvilFarmOwner.LogicTests.csproj \
   -p:EnableAcceptanceFaults=false \
   -p:EnableStorageSortAcceptance=false \
+  -p:EnableMultiplayerAcceptance=false \
   -p:EnableModDeploy=false \
   -p:EnableModZip=false
 
@@ -44,6 +45,7 @@ dotnet build EvilFarmOwner.csproj \
   -c Release \
   -p:EnableAcceptanceFaults=false \
   -p:EnableStorageSortAcceptance=false \
+  -p:EnableMultiplayerAcceptance=false \
   -p:EnableModDeploy=false \
   -p:EnableModZip=true
 
@@ -76,7 +78,7 @@ if ! cmp -s LICENSE <(unzip -p "$package_path" EvilFarmOwner/LICENSE); then
 fi
 
 dll_search_text="$(LC_ALL=C tr -d '\000' < "$project_root/bin/Release/net6.0/EvilFarmOwner.dll")"
-if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_faults|efo_storage_sort_fixture|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
+if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_faults|efo_storage_sort_fixture|efo_multiplayer_acceptance|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
   echo "Release DLL still exposes a legacy prototype or acceptance-test command/setting." >&2
   exit 1
 fi

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -73,6 +73,7 @@ List<(string Name, Action Test)> tests = new()
     ("emergency drop tile ordering", TestEmergencyDropTileOrdering),
     ("multiplayer request authorization", TestMultiplayerRequestAuthorization),
     ("multiplayer request replay", TestMultiplayerRequestReplay),
+    ("multiplayer acceptance replay buffer", TestMultiplayerAcceptanceReplayBuffer),
     ("multiplayer deterministic order", TestMultiplayerDeterministicOrder),
     ("multiplayer reconnect ledger", TestMultiplayerReconnectLedger),
     ("multiplayer restart recovery state", TestMultiplayerRestartRecoveryState),
@@ -1819,6 +1820,40 @@ static void TestMultiplayerRequestReplay()
     Equal(1, ledger.Count);
     Equal(true, ledger.TryGet(1, "request-a", out ContractStartResponseMessage? stored));
     Equal(1L, stored!.HostOrder);
+}
+
+static void TestMultiplayerAcceptanceReplayBuffer()
+{
+    ContractStartRequestMessage original = new()
+    {
+        SchemaVersion = MultiplayerContractProtocol.SchemaVersion,
+        ModVersion = "0.1.0-beta.1",
+        SaveId = 445566,
+        TotalDays = 17,
+        RequestId = Guid.NewGuid().ToString("N"),
+        RequestingPlayerId = 27,
+        WorkerName = "Leah",
+        Task = NamedFarmTask.Harvesting
+    };
+    MultiplayerAcceptanceReplayBuffer buffer = new();
+    Equal(false, buffer.HasRequest);
+    Equal(false, buffer.TryCreateReplay(27, out _));
+
+    buffer.Capture(original);
+    original.WorkerName = "ChangedAfterCapture";
+    Equal(true, buffer.HasRequest);
+    Equal(false, buffer.TryCreateReplay(99, out _));
+    Equal(true, buffer.TryCreateReplay(27, out ContractStartRequestMessage? replay));
+    Equal(false, ReferenceEquals(original, replay));
+    Equal("Leah", replay!.WorkerName);
+    Equal(original.RequestId, replay.RequestId);
+    Equal(original.SaveId, replay.SaveId);
+    Equal(original.TotalDays, replay.TotalDays);
+    Equal(original.Task, replay.Task);
+
+    replay.WorkerName = "ChangedReplay";
+    Equal(true, buffer.TryCreateReplay(27, out ContractStartRequestMessage? secondReplay));
+    Equal("Leah", secondReplay!.WorkerName);
 }
 
 static void TestMultiplayerDeterministicOrder()


### PR DESCRIPTION
## Summary

- add a compile-gated farmhand command that preserves and replays the last exact contract request through the ordinary SMAPI path
- keep replay subject to the normal host session, sender, request-ledger, worker, task, save, and world validation
- document the two-process host-restart procedure, require an unclaimed cabin/two distinct player IDs, and keep the farmhand process open
- make the production verifier explicitly disable and reject all acceptance-only command surfaces

## Linked Issue

Relates #33. This stacked Draft targets PR #68 so the same two-peer build includes the reviewed sorting fixture, route isolation, requester-first delivery, and #42 fault harness. It does not close #33; the real host/farmhand matrix is still required.

## Validation

- [x] 82/82 deterministic tests
- [x] clean `./scripts/verify-release.sh`
- [x] Release build 0 warnings / 0 errors
- [x] production DLL excludes all three acceptance commands
- [x] temporary integrated build contains all three commands and `normal-storage`
- [x] isolated host/farmhand XDG and Mods profiles contain the same exact DLL
- [ ] connected as two independent SMAPI processes
- [ ] real host restart and exact request replay passed

## Evidence

- verified local commit: `b35d86df9e6df3787a01f368a548fec6fb696209`
- remote head: `24233e6f863672de08944e2ce29b5d1a8debc1f2`
- source tree: `b4b802ab186a411e8d34aed6bc7e6e9f1167dce2`
- production ZIP SHA-256: `3b83c04a5501bf059b7aa4b5427808615dcceb2f6ea9c002a69db1405927d4fb`
- temporary integrated acceptance DLL SHA-256: `b68f51221578231d1a835b2c90122dcb60ec22c1c489dd7b837d7ea2bab32b4b`

The acceptance DLL is installed only in isolated temporary peer profiles. It has not been deployed to the normal Mods directory and must never be packaged or distributed.
