### PR TITLE
docs(storage): correct fault acceptance setup

### DIFF
--- a/docs/STORAGE_FAULT_ACCEPTANCE.md
+++ b/docs/STORAGE_FAULT_ACCEPTANCE.md
@@ -21,8 +21,10 @@ SMAPI must log `ACCEPTANCE TEST BUILD` at startup. The command
 
 ## Scenario A: persistent recovery record
 
-1. Prepare one mature crop. Remove eligible chests and completely fill the
-   requesting player's inventory.
+1. Prepare one mature crop. Keep at least one ordinary eligible main-farm chest
+   so the harvest dispatch preflight can pass, but fill every eligible chest so
+   none can accept the harvested stack. Completely fill the requesting player's
+   inventory too.
 2. Run:
 
    ```text
@@ -41,7 +43,7 @@ SMAPI must log `ACCEPTANCE TEST BUILD` at startup. The command
 
 ## Scenario B: save-boundary forced quarantine
 
-1. Prepare the same no-chest/full-inventory setup and run:
+1. Prepare the same full-chest/full-inventory setup and run:
 
    ```text
    efo_acceptance_faults arm overflow-lock visible-drop quarantine-lock recovery-record-write


### PR DESCRIPTION
## Summary

- keep the ordinary main-farm chest required by harvest dispatch preflight
- fill every eligible chest and the requester inventory so the captured stack still reaches the forced emergency-storage path
- reuse the same feasible setup for the save-boundary scenario

## Linked Issue

Relates #42. This corrects the live gate; #42 remains open until the three forced-failure scenarios pass.

## Change Type

- [ ] `feat`: user-facing feature
- [ ] `fix`: bug fix
- [x] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [ ] `test`: test or validation work

## Validation

- [x] `git diff --check` and repository source-validation commands pass
- [x] Confirmed `HarvestingContractExecutionController.TryStart` rejects dispatch when `HarvestChestRouter.HasEligibleChest` is false
- [x] Confirmed a present-but-full eligible chest passes that existence preflight while leaving no normal destination for the captured stack
- [x] No production code or package content changed

## Notes

The previous “remove eligible chests” instruction could never reach fault injection because harvest dispatch stopped at `harvest.start.no-storage-chest` before wage, lease, or crop mutation.

Remote commit: `5f08834edf0dd36422add7bb8dacec7aae9aa10b`  
Remote tree: `8bb0ba18ac524821d25d1aa70efdbb8c8b7eb9d2`
