### PR TITLE
test(storage): inject ordinary delivery failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added bilingual task selection, contract settlement HUDs, host-authoritative protocol 7 snapshots/results, and persistent per-transfer source/destination reports.
 - Isolated a crop after its live interaction routes are exhausted instead of marking every remaining crop unreachable; three independently stalled crops at one origin still trigger a bounded safe return.
 - Delivered each complete harvest stack to the original requesting player first when they are online, on the same main farm, and have enough inventory capacity; otherwise retained deterministic classified-chest routing.
+- Added an acceptance-only ordinary-storage rejection fault so overflow, visible-drop, quarantine, and recovery-record safety can be tested without manually filling every chest and player slot.
 - Kept recurring automatic chest sorting disabled until the manual contract passes live acceptance.
 
 ## 0.1.0-beta.1 - 2026-08-24

--- a/HarvestAcceptanceFaults.cs
+++ b/HarvestAcceptanceFaults.cs
@@ -8,7 +8,8 @@ internal enum HarvestAcceptanceFault
     VisibleDrop = 1 << 1,
     QuarantineLock = 1 << 2,
     RecoveryRecordWrite = 1 << 3,
-    QuarantineWrite = 1 << 4
+    QuarantineWrite = 1 << 4,
+    NormalStorage = 1 << 5
 }
 
 /// <summary>
@@ -52,6 +53,7 @@ internal sealed class HarvestAcceptanceFaults
             "quarantine-lock" => HarvestAcceptanceFault.QuarantineLock,
             "recovery-record-write" => HarvestAcceptanceFault.RecoveryRecordWrite,
             "quarantine-write" => HarvestAcceptanceFault.QuarantineWrite,
+            "normal-storage" => HarvestAcceptanceFault.NormalStorage,
             _ => HarvestAcceptanceFault.None
         };
         return fault != HarvestAcceptanceFault.None;
@@ -66,6 +68,7 @@ internal sealed class HarvestAcceptanceFaults
             HarvestAcceptanceFault.QuarantineLock => "quarantine-lock",
             HarvestAcceptanceFault.RecoveryRecordWrite => "recovery-record-write",
             HarvestAcceptanceFault.QuarantineWrite => "quarantine-write",
+            HarvestAcceptanceFault.NormalStorage => "normal-storage",
             _ => "none"
         };
     }

--- a/HarvestingContractExecutionController.cs
+++ b/HarvestingContractExecutionController.cs
@@ -849,6 +849,15 @@ internal sealed class HarvestingContractExecutionController
         }
 
         HarvestCargoEntry entry = contract.Cargo[0];
+        if (this.AcceptanceFaults.IsArmed(HarvestAcceptanceFault.NormalStorage))
+        {
+            this.LogInjectedFault(HarvestAcceptanceFault.NormalStorage);
+            this.StopForUnavailableStorage(
+                contract,
+                "acceptance testing forced ordinary requester and chest storage to reject the stack");
+            return;
+        }
+
         if (this.TryDeliverToOnFarmRequester(contract, entry))
             return;
 

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -123,7 +123,7 @@ public sealed class ModEntry : Mod
         if (!string.Equals(args[0], "arm", StringComparison.OrdinalIgnoreCase) || args.Length < 2)
         {
             this.Monitor.Log(
-                "Usage: efo_acceptance_faults arm <overflow-lock|visible-drop|quarantine-lock|recovery-record-write|quarantine-write> [...]; clear; status; finalize",
+                "Usage: efo_acceptance_faults arm <normal-storage|overflow-lock|visible-drop|quarantine-lock|recovery-record-write|quarantine-write> [...]; clear; status; finalize",
                 LogLevel.Info);
             return;
         }

--- a/docs/STORAGE_FAULT_ACCEPTANCE.md
+++ b/docs/STORAGE_FAULT_ACCEPTANCE.md
@@ -21,12 +21,13 @@ SMAPI must log `ACCEPTANCE TEST BUILD` at startup. The command
 
 ## Scenario A: persistent recovery record
 
-1. Prepare one mature crop. Remove eligible chests and completely fill the
-   requesting player's inventory.
+1. Prepare one mature crop and keep at least one ordinary eligible main-farm
+   chest so the normal harvest dispatch preflight can pass. Its contents and the
+   requesting player's free inventory space do not matter in this acceptance build.
 2. Run:
 
    ```text
-   efo_acceptance_faults arm overflow-lock visible-drop quarantine-lock
+   efo_acceptance_faults arm normal-storage overflow-lock visible-drop quarantine-lock
    ```
 
 3. Hire an NPC to harvest. After the item is captured, run
@@ -41,10 +42,10 @@ SMAPI must log `ACCEPTANCE TEST BUILD` at startup. The command
 
 ## Scenario B: save-boundary forced quarantine
 
-1. Prepare the same no-chest/full-inventory setup and run:
+1. Prepare the same one-crop/one-eligible-chest setup and run:
 
    ```text
-   efo_acceptance_faults arm overflow-lock visible-drop quarantine-lock recovery-record-write
+   efo_acceptance_faults arm normal-storage overflow-lock visible-drop quarantine-lock recovery-record-write
    ```
 
 2. Hire an NPC to harvest. After capture, run
@@ -57,7 +58,13 @@ SMAPI must log `ACCEPTANCE TEST BUILD` at startup. The command
 
 ## Scenario C: fail-closed terminal write
 
-Arm all five faults, capture one output, then invoke `finalize`. Verify the log
+Arm all six faults with:
+
+```text
+efo_acceptance_faults arm normal-storage overflow-lock visible-drop quarantine-lock recovery-record-write quarantine-write
+```
+
+Capture one output, then invoke `finalize`. Verify the log
 contains a CRITICAL save-boundary failure, the active contract remains reported,
 no successful result is published, and no second contract can start. This is a
 negative safety observation, not a releasable success path; clear the faults and

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -1653,6 +1653,7 @@ static void TestHarvestAcceptanceFaultControls()
 {
     HarvestAcceptanceFaults faults = new();
     Equal("none", faults.Describe());
+    Equal(true, HarvestAcceptanceFaults.TryParse("normal-storage", out HarvestAcceptanceFault normalStorage));
     Equal(true, HarvestAcceptanceFaults.TryParse("overflow-lock", out HarvestAcceptanceFault overflow));
     Equal(true, HarvestAcceptanceFaults.TryParse("VISIBLE-DROP", out HarvestAcceptanceFault visibleDrop));
     Equal(true, HarvestAcceptanceFaults.TryParse("quarantine-lock", out HarvestAcceptanceFault quarantineLock));
@@ -1660,18 +1661,20 @@ static void TestHarvestAcceptanceFaultControls()
     Equal(true, HarvestAcceptanceFaults.TryParse("quarantine-write", out HarvestAcceptanceFault quarantineWrite));
     Equal(false, HarvestAcceptanceFaults.TryParse("unknown", out _));
 
+    faults.Arm(normalStorage);
     faults.Arm(overflow);
     faults.Arm(visibleDrop);
     faults.Arm(quarantineLock);
     faults.Arm(recoveryWrite);
     faults.Arm(quarantineWrite);
+    Equal(true, faults.IsArmed(HarvestAcceptanceFault.NormalStorage));
     Equal(true, faults.IsArmed(HarvestAcceptanceFault.OverflowLock));
     Equal(true, faults.IsArmed(HarvestAcceptanceFault.VisibleDrop));
     Equal(true, faults.IsArmed(HarvestAcceptanceFault.QuarantineLock));
     Equal(true, faults.IsArmed(HarvestAcceptanceFault.RecoveryRecordWrite));
     Equal(true, faults.IsArmed(HarvestAcceptanceFault.QuarantineWrite));
     Equal(
-        "overflow-lock,visible-drop,quarantine-lock,recovery-record-write,quarantine-write",
+        "overflow-lock,visible-drop,quarantine-lock,recovery-record-write,quarantine-write,normal-storage",
         faults.Describe());
 
     faults.Clear();


### PR DESCRIPTION
## Summary

- add a `normal-storage` acceptance-only fault that rejects both requester inventory and chest delivery after an exact harvest output is captured
- preserve the ordinary production dispatch preflight, then enter the real overflow/drop/quarantine/recovery chain without filling every chest and player slot
- update the three #42 live scenarios, changelog, and deterministic fault parsing/arming coverage

## Safety boundary

The command remains behind `EnableAcceptanceFaults=true`. The clean production verifier rebuilds with the flag disabled and rejects `efo_acceptance_faults` in the DLL. This PR does not change ordinary production behavior when no acceptance fault is armed.

## Verification

- Release build: 0 warnings, 0 errors
- deterministic logic tests: 80/80 passed
- clean `./scripts/verify-release.sh`: passed
- source tree: `442194b7a684e8f1917c85475d0acace1a64ebdc`
- verified local commit: `b829d62075c48c5227fb66ff316c4cc2ea82d327`
- remote head: `a8639f25fe4e92794ae5f9a9f7ac0346e0ba29e9`
- production ZIP SHA-256: `69a6382252af9bf0a98970568c45f0e6182001161eec4c9b02d577757978ee87`

Relates #42. Keep Draft until all three live failure scenarios pass.
