### PR TITLE
test(storage): add deterministic sorting fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Isolated a crop after its live interaction routes are exhausted instead of marking every remaining crop unreachable; three independently stalled crops at one origin still trigger a bounded safe return.
 - Delivered each complete harvest stack to the original requesting player first when they are online, on the same main farm, and have enough inventory capacity; otherwise retained deterministic classified-chest routing.
 - Added an acceptance-only ordinary-storage rejection fault so overflow, visible-drop, quarantine, and recovery-record safety can be tested without manually filling every chest and player slot.
+- Added an acceptance-only five-chest sorting fixture which proves exact-stack, same-item, same-category, empty fallback, conservation, and second-run idempotence on a disposable save.
 - Kept recurring automatic chest sorting disabled until the manual contract passes live acceptance.
 
 ## 0.1.0-beta.1 - 2026-08-24

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -8,10 +8,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableAcceptanceFaults Condition="'$(EnableAcceptanceFaults)' == ''">false</EnableAcceptanceFaults>
+    <EnableStorageSortAcceptance Condition="'$(EnableStorageSortAcceptance)' == ''">false</EnableStorageSortAcceptance>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EnableAcceptanceFaults)' == 'true'">
     <DefineConstants>$(DefineConstants);EFO_ACCEPTANCE_FAULTS</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(EnableStorageSortAcceptance)' == 'true'">
+    <DefineConstants>$(DefineConstants);EFO_STORAGE_SORT_ACCEPTANCE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -87,7 +87,63 @@ public sealed class ModEntry : Mod
             "ACCEPTANCE TEST BUILD: harvest storage fault injection is enabled. Do not distribute this DLL.",
             LogLevel.Alert);
 #endif
+#if EFO_STORAGE_SORT_ACCEPTANCE
+        helper.ConsoleCommands.Add(
+            "efo_storage_sort_fixture",
+            "Create or inspect the isolated five-chest sorting acceptance fixture. Excluded from production builds.",
+            this.HandleStorageSortFixtureCommand);
+        this.Monitor.Log(
+            "ACCEPTANCE TEST BUILD: chest-sorting fixture setup is enabled. Use only on a disposable save.",
+            LogLevel.Alert);
+#endif
     }
+
+#if EFO_STORAGE_SORT_ACCEPTANCE
+    private void HandleStorageSortFixtureCommand(string command, string[] args)
+    {
+        if (!Context.IsWorldReady || !Context.IsMainPlayer)
+        {
+            this.Monitor.Log("The sorting fixture requires an active host save.", LogLevel.Warn);
+            return;
+        }
+
+        if (this.HasActiveNamedContract())
+        {
+            this.Monitor.Log("Finish the active named contract before inspecting or creating the fixture.", LogLevel.Warn);
+            return;
+        }
+
+        string action = args.FirstOrDefault()?.Trim().ToLowerInvariant() ?? "status";
+        if (action == "status")
+        {
+            this.Monitor.Log(StorageSortAcceptanceFixture.Describe(Game1.getFarm()), LogLevel.Info);
+            return;
+        }
+
+        if (action != "setup")
+        {
+            this.Monitor.Log("Usage: efo_storage_sort_fixture <setup|status>", LogLevel.Info);
+            return;
+        }
+
+        if (!ReferenceEquals(Game1.player.currentLocation, Game1.getFarm()))
+        {
+            this.Monitor.Log("Stand on the main farm before creating the sorting fixture.", LogLevel.Warn);
+            return;
+        }
+
+        if (StorageSortAcceptanceFixture.TrySetup(
+                Game1.getFarm(),
+                Game1.player.TilePoint,
+                out string result))
+        {
+            this.Monitor.Log(result, LogLevel.Alert);
+            return;
+        }
+
+        this.Monitor.Log(result, LogLevel.Warn);
+    }
+#endif
 
 #if EFO_ACCEPTANCE_FAULTS
     private void HandleAcceptanceFaultCommand(string command, string[] args)

--- a/StorageSortAcceptanceFixture.cs
+++ b/StorageSortAcceptanceFixture.cs
@@ -1,0 +1,224 @@
+using Microsoft.Xna.Framework;
+using StardewValley;
+using StardewValley.Locations;
+using StardewValley.Objects;
+
+namespace EvilFarmOwner;
+
+internal sealed record StorageSortFixtureItem(
+    string QualifiedItemId,
+    int Category,
+    int Quantity,
+    int Quality = 0,
+    int MaximumStackSize = 999);
+
+internal static class StorageSortAcceptanceFixture
+{
+    private const string FixtureDataKey = "Aveouter.EvilFarmOwner/StorageSortFixture";
+    private const string FixtureVersion = "1";
+    private const int FixtureChestCount = 5;
+    private const int ExpectedTransferCount = 4;
+
+    private static readonly IReadOnlyList<IReadOnlyList<StorageSortFixtureItem>> FixtureContents =
+        new IReadOnlyList<StorageSortFixtureItem>[]
+        {
+            new StorageSortFixtureItem[]
+            {
+                new("(O)24", -75, 10),
+                new("(O)192", -75, 5)
+            },
+            new StorageSortFixtureItem[]
+            {
+                new("(O)382", -15, 1)
+            },
+            new StorageSortFixtureItem[]
+            {
+                new("(O)635", -79, 1)
+            },
+            Array.Empty<StorageSortFixtureItem>(),
+            new StorageSortFixtureItem[]
+            {
+                new("(O)390", -16, 20),
+                new("(O)382", -15, 5),
+                new("(O)613", -79, 3),
+                new("(O)770", -74, 4),
+                new("(O)24", -75, 2, Quality: 1)
+            }
+        };
+
+    public static IReadOnlyList<StorageSortChestSnapshot> CreateSnapshots(
+        IReadOnlyList<GridPoint> tiles)
+    {
+        if (tiles.Count != FixtureChestCount)
+            throw new ArgumentException($"Expected {FixtureChestCount} fixture tiles.", nameof(tiles));
+
+        List<StorageSortChestSnapshot> snapshots = new(FixtureChestCount);
+        for (int chestIndex = 0; chestIndex < FixtureChestCount; chestIndex++)
+        {
+            IReadOnlyList<StorageSortStackSnapshot> stacks = FixtureContents[chestIndex]
+                .Select((item, slot) => new StorageSortStackSnapshot(
+                    $"fixture:{chestIndex}:{slot}",
+                    $"{item.QualifiedItemId}:q{item.Quality}",
+                    item.QualifiedItemId,
+                    item.Category,
+                    item.Quantity,
+                    item.MaximumStackSize))
+                .ToArray();
+            snapshots.Add(new StorageSortChestSnapshot(tiles[chestIndex], 36, stacks));
+        }
+
+        return snapshots;
+    }
+
+    public static bool TrySetup(Farm farm, Point playerTile, out string result)
+    {
+        result = string.Empty;
+        Dictionary<GridPoint, Chest> eligible = StorageSortSnapshotService.GetEligibleChests(farm);
+        if (eligible.Count > 0)
+        {
+            result = $"Fixture setup refused: the main farm already has {eligible.Count} eligible chest(s). Use the isolated chest-free save copy.";
+            return false;
+        }
+
+        if (GetFixtureChests(farm).Count > 0)
+        {
+            result = "Fixture setup refused: tagged fixture chests already exist.";
+            return false;
+        }
+
+        if (!TryFindLayout(farm, new GridPoint(playerTile.X, playerTile.Y), out GridPoint[]? tiles)
+            || tiles is null)
+        {
+            result = "Fixture setup could not find five chest tiles with a clear interaction row near the player.";
+            return false;
+        }
+
+        List<Vector2> insertedTiles = new();
+        try
+        {
+            for (int index = 0; index < tiles.Length; index++)
+            {
+                Vector2 tile = new(tiles[index].X, tiles[index].Y);
+                Chest chest = new(playerChest: true, tile);
+                chest.modData[FixtureDataKey] = FixtureVersion;
+                foreach (StorageSortFixtureItem fixtureItem in FixtureContents[index])
+                {
+                    Item item = ItemRegistry.Create(
+                        fixtureItem.QualifiedItemId,
+                        fixtureItem.Quantity,
+                        fixtureItem.Quality);
+                    if (item.Category != fixtureItem.Category
+                        || item.maximumStackSize() != fixtureItem.MaximumStackSize)
+                    {
+                        throw new InvalidDataException(
+                            $"Fixture item {fixtureItem.QualifiedItemId} no longer matches its reviewed category/stack metadata.");
+                    }
+                    chest.Items.Add(item);
+                }
+
+                farm.objects.Add(tile, chest);
+                insertedTiles.Add(tile);
+            }
+
+            Dictionary<GridPoint, Chest> fixtureChests = GetFixtureChests(farm);
+            StorageSortRuntimePlanResult preflight = StorageSortSnapshotService.TryCreate(fixtureChests);
+            int transferCount = preflight.RuntimePlan?.Plan.Transfers.Count ?? 0;
+            if (!preflight.IsSuccess || transferCount != ExpectedTransferCount)
+            {
+                throw new InvalidDataException(
+                    $"Fixture preflight expected {ExpectedTransferCount} transfers but returned {preflight.Failure}/{transferCount}.");
+            }
+
+            result = $"Created the isolated five-chest sorting fixture at {string.Join(", ", tiles.Select(tile => $"({tile.X},{tile.Y})"))}. Preflight has exactly {transferCount} transfers; start one manual sorting contract, then run efo_storage_sort_fixture status.";
+            return true;
+        }
+        catch (Exception ex)
+        {
+            foreach (Vector2 tile in insertedTiles)
+            {
+                if (farm.objects.TryGetValue(tile, out StardewValley.Object? item)
+                    && item is Chest chest
+                    && IsFixtureChest(chest))
+                {
+                    farm.objects.Remove(tile);
+                }
+            }
+
+            result = $"Fixture setup rolled back without retaining test chests: {ex.Message}";
+            return false;
+        }
+    }
+
+    public static string Describe(Farm farm)
+    {
+        Dictionary<GridPoint, Chest> chests = GetFixtureChests(farm);
+        if (chests.Count == 0)
+            return "Storage sorting fixture is not present.";
+        if (chests.Count != FixtureChestCount)
+            return $"Storage sorting fixture is invalid: found {chests.Count}/{FixtureChestCount} tagged chests.";
+
+        StorageSortRuntimePlanResult status = StorageSortSnapshotService.TryCreate(chests);
+        if (status.Failure == StorageSortSnapshotFailure.NoTransfers)
+            return "Storage sorting fixture converged: no transfers remain. A second contract must reject before wage reservation or NPC lease.";
+        if (status.IsSuccess)
+            return $"Storage sorting fixture is ready: {status.RuntimePlan!.Plan.Transfers.Count} deterministic transfer(s) remain.";
+        return $"Storage sorting fixture is invalid: preflight returned {status.Failure}.";
+    }
+
+    private static Dictionary<GridPoint, Chest> GetFixtureChests(Farm farm)
+    {
+        return farm.objects.Pairs
+            .Where(pair => pair.Value is Chest chest && IsFixtureChest(chest))
+            .ToDictionary(
+                pair => new GridPoint((int)pair.Key.X, (int)pair.Key.Y),
+                pair => (Chest)pair.Value);
+    }
+
+    private static bool IsFixtureChest(Chest chest)
+    {
+        return chest.modData.TryGetValue(FixtureDataKey, out string? version)
+            && string.Equals(version, FixtureVersion, StringComparison.Ordinal);
+    }
+
+    private static bool TryFindLayout(
+        Farm farm,
+        GridPoint anchor,
+        out GridPoint[]? tiles)
+    {
+        tiles = null;
+        int width = farm.Map.Layers[0].LayerWidth;
+        int height = farm.Map.Layers[0].LayerHeight;
+        IEnumerable<GridPoint> origins = Enumerable
+            .Range(1, Math.Max(0, height - 3))
+            .SelectMany(y => Enumerable.Range(1, Math.Max(0, width - 10)).Select(x => new GridPoint(x, y)))
+            .OrderBy(origin => Math.Abs(origin.X - anchor.X) + Math.Abs(origin.Y - anchor.Y))
+            .ThenBy(origin => origin.Y)
+            .ThenBy(origin => origin.X);
+
+        foreach (GridPoint origin in origins)
+        {
+            GridPoint[] candidate = Enumerable.Range(0, FixtureChestCount)
+                .Select(index => new GridPoint(origin.X + index * 2, origin.Y))
+                .ToArray();
+            bool clear = candidate.All(tile =>
+            {
+                Vector2 chestTile = new(tile.X, tile.Y);
+                Vector2 interactionTile = new(tile.X, tile.Y + 1);
+                return farm.CanItemBePlacedHere(chestTile)
+                    && farm.CanItemBePlacedHere(interactionTile)
+                    && !farm.warps.Any(warp =>
+                        (warp.X == tile.X && warp.Y == tile.Y)
+                        || (warp.X == tile.X && warp.Y == tile.Y + 1))
+                    && !farm.doors.ContainsKey(new Point(tile.X, tile.Y))
+                    && !farm.doors.ContainsKey(new Point(tile.X, tile.Y + 1));
+            });
+            if (!clear)
+                continue;
+
+            tiles = candidate;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/docs/STORAGE_SORT_ACCEPTANCE.md
+++ b/docs/STORAGE_SORT_ACCEPTANCE.md
@@ -1,0 +1,23 @@
+# Deterministic Chest-Sorting Acceptance
+
+Use only the isolated disposable save copy. The fixture command is excluded
+from ordinary production builds.
+
+1. Quit every running Stardew Valley process. Build with
+   `-p:EnableStorageSortAcceptance=true`, deploy only to the isolated Mods
+   profile, and load a main farm with no ordinary eligible farm chests.
+2. Stand in an open part of the main farm and run
+   `efo_storage_sort_fixture setup`. The command must report exactly five
+   tagged chests and four preflighted transfers.
+3. Hire an available adult NPC for one manual chest-sorting contract. Verify
+   the four complete stacks exercise exact-stack, same-item/different-quality,
+   same-category, and empty-chest routing without touching player inventory or
+   the shipping bin.
+4. Compare the completion report with the four source/destination chest tiles,
+   item IDs, categories, qualities and quantities. No unrelated stack may
+   change and the exact total item count must be conserved.
+5. Run `efo_storage_sort_fixture status`. It must report `converged` and no
+   remaining transfer. A second contract request must reject before reserving
+   wages or leasing the NPC.
+6. Retain the SMAPI log, then discard the isolated save copy. Never distribute
+   the fixture-enabled DLL.

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -35,6 +35,7 @@ dotnet run \
   -c Release \
   --project tests/EvilFarmOwner.LogicTests.csproj \
   -p:EnableAcceptanceFaults=false \
+  -p:EnableStorageSortAcceptance=false \
   -p:EnableModDeploy=false \
   -p:EnableModZip=false
 
@@ -42,6 +43,7 @@ dotnet build EvilFarmOwner.csproj \
   -t:Rebuild \
   -c Release \
   -p:EnableAcceptanceFaults=false \
+  -p:EnableStorageSortAcceptance=false \
   -p:EnableModDeploy=false \
   -p:EnableModZip=true
 
@@ -74,7 +76,7 @@ if ! cmp -s LICENSE <(unzip -p "$package_path" EvilFarmOwner/LICENSE); then
 fi
 
 dll_search_text="$(LC_ALL=C tr -d '\000' < "$project_root/bin/Release/net6.0/EvilFarmOwner.dll")"
-if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_faults|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
+if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_faults|efo_storage_sort_fixture|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
   echo "Release DLL still exposes a legacy prototype or acceptance-test command/setting." >&2
   exit 1
 fi

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -51,6 +51,7 @@ List<(string Name, Action Test)> tests = new()
     ("storage sort stable tie", TestStorageSortStableTie),
     ("storage sort capacity preflight", TestStorageSortCapacityPreflight),
     ("storage sort idempotence", TestStorageSortIdempotence),
+    ("storage sort acceptance fixture", TestStorageSortAcceptanceFixture),
     ("storage sort conservation", TestStorageSortConservation),
     ("storage sort invalid snapshot", TestStorageSortInvalidSnapshot),
     ("storage sort generated invariants", TestStorageSortGeneratedInvariants),
@@ -1018,6 +1019,36 @@ static void TestStorageSortIdempotence()
     StorageSortPlan second = StorageSortPlanner.Create(first.ResultChests);
     Equal(true, second.CanExecute);
     Equal(0, second.Transfers.Count);
+}
+
+static void TestStorageSortAcceptanceFixture()
+{
+    GridPoint[] tiles =
+    {
+        new(0, 0),
+        new(2, 0),
+        new(4, 0),
+        new(6, 0),
+        new(8, 0)
+    };
+    IReadOnlyList<StorageSortChestSnapshot> source = StorageSortAcceptanceFixture.CreateSnapshots(tiles);
+    StorageSortPlan first = StorageSortPlanner.Create(source);
+    Equal(StorageSortPlanFailure.None, first.Failure);
+    Equal(4, first.Transfers.Count);
+    Equal(new GridPoint(2, 0), first.Transfers.Single(transfer =>
+        transfer.StackingKey == "(O)382:q0").DestinationChest);
+    Equal(new GridPoint(4, 0), first.Transfers.Single(transfer =>
+        transfer.StackingKey == "(O)613:q0").DestinationChest);
+    Equal(new GridPoint(6, 0), first.Transfers.Single(transfer =>
+        transfer.StackingKey == "(O)770:q0").DestinationChest);
+    Equal(new GridPoint(0, 0), first.Transfers.Single(transfer =>
+        transfer.StackingKey == "(O)24:q1").DestinationChest);
+
+    StorageSortPlan second = StorageSortPlanner.Create(first.ResultChests);
+    Equal(StorageSortPlanFailure.None, second.Failure);
+    Equal(0, second.Transfers.Count);
+    Equal(SortQuantity(source), SortQuantity(first.ResultChests));
+    Equal(SortTotals(source), SortTotals(first.ResultChests));
 }
 
 static void TestStorageSortConservation()


### PR DESCRIPTION
## Summary

- add a compile-gated `efo_storage_sort_fixture` command for disposable acceptance saves only
- create five tagged ordinary chests in a dynamically selected clear layout and seed exactly four reviewed moves: exact stack, same item at another quality, same category, and empty fallback
- run the real runtime snapshot/planner before retaining the fixture; any mismatch rolls back every inserted test chest
- report `converged` only when the real planner finds no second-run transfer
- document the manual gate, add conservation/idempotence coverage, and make the production verifier reject the command

## Safety boundary

The fixture refuses farms which already contain any eligible ordinary chest, refuses active contracts, requires the host to stand on the main farm, tags only its own new chests, and rolls back those chests on setup failure. It is enabled only with `EnableStorageSortAcceptance=true` and must never be distributed.

## Verification

- instrumented Release build: 0 warnings, 0 errors
- deterministic tests: 81/81 passed
- strict format verification: passed
- clean production verifier: passed and rejects `efo_storage_sort_fixture`
- source tree: `2e712c95e971402545d82d03c932f146258a112d`
- verified local commit: `a741488b0d6eb2c00b0cf31537a06b87e9c6824b`
- remote head: `25b662d73f702aba2f624d3918d1989388484f67`
- production ZIP SHA-256: `fe63399d18b8d7c396e579ee056a5965f7addd1d1f333ee3bbbc927f822ae1fd`

Relates #7. Keep Draft until the isolated live sorting and second-run rejection pass.
