### PR TITLE
fix(harvest): defer consecutive chest reacquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Deferred harvest delivery until the next update after releasing a chest mutex, preventing consecutive outputs routed to the same chest from being falsely rejected as unreachable.
+
 ## 0.1.0-beta.1 - 2026-08-24
 
 - Published the first explicitly non-stable test build under the MIT License.

--- a/HarvestChestReleaseDelay.cs
+++ b/HarvestChestReleaseDelay.cs
@@ -1,0 +1,14 @@
+namespace EvilFarmOwner;
+
+/// <summary>
+/// Prevents a chest mutex from being reacquired from inside its own release callback.
+/// </summary>
+internal static class HarvestChestReleaseDelay
+{
+    private const int MinimumElapsedTicks = 1;
+
+    public static bool CanContinue(int elapsedTicks)
+    {
+        return elapsedTicks >= MinimumElapsedTicks;
+    }
+}

--- a/HarvestingContractExecutionController.cs
+++ b/HarvestingContractExecutionController.cs
@@ -299,6 +299,11 @@ internal sealed class HarvestingContractExecutionController
                 }
                 break;
 
+            case HarvestContractPhase.WaitingForChestRelease:
+                if (HarvestChestReleaseDelay.CanContinue(contract.PhaseTicks))
+                    this.BeginDeliveryOrReturn(contract);
+                break;
+
             case HarvestContractPhase.WaitingForOverflowLock:
                 if (contract.PhaseTicks >= MaximumOverflowWaitTicks)
                 {
@@ -984,7 +989,12 @@ internal sealed class HarvestingContractExecutionController
         if (storageBecameUnavailable)
             this.StopForUnavailableStorage(contract, "a locked chest stopped accepting the full stack");
         else
-            this.BeginDeliveryOrReturn(contract);
+        {
+            // NetMutex release completion is not re-entrant. Requesting the same chest again
+            // from this acquisition callback can receive a false lock-failure response.
+            contract.Phase = HarvestContractPhase.WaitingForChestRelease;
+            contract.PhaseTicks = 0;
+        }
     }
 
     private void OnChestLockFailed(Guid contractId, HarvestChestRoute route)
@@ -2194,6 +2204,7 @@ internal sealed class HarvestingContractExecutionController
         Acting,
         TravelingToChest,
         WaitingForChestLock,
+        WaitingForChestRelease,
         WaitingForOverflowLock,
         QuarantiningCargo,
         Returning,

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -59,6 +59,7 @@ List<(string Name, Action Test)> tests = new()
     ("storage sort interaction ordering", TestStorageSortInteractionOrdering),
     ("storage sort report accounting", TestStorageSortReportAccounting),
     ("harvest partial remainder", TestHarvestPartialRemainder),
+    ("harvest chest release deferral", TestHarvestChestReleaseDeferral),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
     ("harvest transfer replay protection", TestHarvestTransferReplayProtection),
@@ -1354,6 +1355,26 @@ static void TestHarvestPartialRemainder()
     Equal(6, HarvestTransferMath.GetDeliveredCount(requestedStack: 10, remainingStack: 4));
     Equal(0, HarvestTransferMath.GetDeliveredCount(requestedStack: 10, remainingStack: 10));
     Equal(10, HarvestTransferMath.GetDeliveredCount(requestedStack: 10, remainingStack: 0));
+}
+
+static void TestHarvestChestReleaseDeferral()
+{
+    int remainingCargoStacks = 2;
+    int deliveredStacks = 0;
+
+    remainingCargoStacks--;
+    deliveredStacks++;
+
+    Equal(false, HarvestChestReleaseDelay.CanContinue(elapsedTicks: 0));
+    Equal(1, remainingCargoStacks);
+    Equal(1, deliveredStacks);
+
+    Equal(true, HarvestChestReleaseDelay.CanContinue(elapsedTicks: 1));
+    remainingCargoStacks--;
+    deliveredStacks++;
+
+    Equal(0, remainingCargoStacks);
+    Equal(2, deliveredStacks);
 }
 
 static void TestRegrowingHarvestCaptureSemantics()


### PR DESCRIPTION
## Summary

- defer harvest delivery for one game update after releasing an ordinary chest mutex
- prevent a consecutive output from reacquiring the same chest inside the prior lock callback
- add a deterministic two-stack regression and document the fix

## Linked issue

Closes #69.

## Root cause

The successful chest-lock callback released NetMutex and immediately called the next delivery from the same callback stack. When the next cargo selected the same chest, the mutex could report a transient lock failure. That chest was then marked attempted for the new transfer, causing a false storage-unavailable stop while reachable crops and sufficient time remained.

## Validation

- latest remote main base: 24108b4c6b0a45239a27c2ee7bf92ed5386e5bee
- deterministic logic tests: 76/76 passed
- Release build: 0 warnings, 0 errors
- clean production verifier: passed
- verified source tree: 52a05e60fcde28f06bee06e916e4cead7710ecfe
- remote commit: 3471c2094e130baa31d1fdaf0c7b151054c18940
- production ZIP SHA-256: fcb2cbbaf221caa94067ba0b57f9aedb6a33799d967dc9e56bfacdd0a509f47c

## Multiplayer impact

The host remains authoritative. This only moves post-release continuation to the next update tick and does not alter transfer IDs, cargo ownership, chest ranking, mutex ownership, or settlement.

## Live gate

Keep Draft until the isolated layout that reproduced the failure completes all reachable mature crops in one contract, performs consecutive deliveries to the same chest without a false lock failure, and finishes with a balanced placement audit.