### PR TITLE
fix(harvest): isolate failed chest approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Isolated a stalled harvest chest interaction route instead of rejecting every approach to that chest, while retaining whole-chest exclusion for storage or mutex failures.
 - Deferred harvest delivery until the next update after releasing a chest mutex, preventing consecutive outputs routed to the same chest from being falsely rejected as unreachable.
 
 ## 0.1.0-beta.1 - 2026-08-24

--- a/HarvestChestRanking.cs
+++ b/HarvestChestRanking.cs
@@ -47,6 +47,23 @@ internal sealed record HarvestChestOption(
     public bool CanFullyAccept => this.AcceptableCapacity >= this.RequestedStack;
 }
 
+internal readonly record struct HarvestChestRouteKey(
+    GridPoint ChestTile,
+    GridPoint InteractionTile);
+
+internal static class HarvestChestRouteAttemptPolicy
+{
+    public static bool IsExcluded(
+        GridPoint chestTile,
+        GridPoint interactionTile,
+        IReadOnlySet<GridPoint> attemptedChestTiles,
+        IReadOnlySet<HarvestChestRouteKey> attemptedRoutes)
+    {
+        return attemptedChestTiles.Contains(chestTile)
+            || attemptedRoutes.Contains(new HarvestChestRouteKey(chestTile, interactionTile));
+    }
+}
+
 internal static class HarvestChestRanking
 {
     public static IReadOnlyList<HarvestChestOption> Order(IEnumerable<HarvestChestOption> options)

--- a/HarvestChestRouter.cs
+++ b/HarvestChestRouter.cs
@@ -37,12 +37,16 @@ internal sealed class HarvestChestRouter
         NPC worker,
         Point startTile,
         Item item,
-        IReadOnlySet<Point> attemptedChestTiles)
+        IReadOnlySet<Point> attemptedChestTiles,
+        IReadOnlySet<HarvestChestRouteKey> attemptedRoutes)
     {
         if (!FarmNavigationMap.TryBuild(farm, worker, startTile, this.Monitor, out GridRouteMap? routes)
             || routes is null)
             return null;
 
+        HashSet<GridPoint> attemptedChestGrids = attemptedChestTiles
+            .Select(tile => new GridPoint(tile.X, tile.Y))
+            .ToHashSet();
         List<(HarvestChestOption Option, Chest Chest, Stack<Point> Path)> candidates = new();
         foreach (KeyValuePair<Vector2, SObject> pair in farm.objects.Pairs)
         {
@@ -50,8 +54,7 @@ internal sealed class HarvestChestRouter
                 continue;
 
             Point chestTile = new((int)pair.Key.X, (int)pair.Key.Y);
-            if (attemptedChestTiles.Contains(chestTile))
-                continue;
+            GridPoint chestGrid = new(chestTile.X, chestTile.Y);
 
             int acceptableCapacity = GetAcceptableCapacity(chest, item);
             if (acceptableCapacity < item.Stack)
@@ -66,13 +69,18 @@ internal sealed class HarvestChestRouter
             {
                 Point interaction = new(chestTile.X + offset.X, chestTile.Y + offset.Y);
                 GridPoint interactionGrid = new(interaction.X, interaction.Y);
-                if (!routes.TryGetDistance(interactionGrid, out int distance)
+                if (HarvestChestRouteAttemptPolicy.IsExcluded(
+                        chestGrid,
+                        interactionGrid,
+                        attemptedChestGrids,
+                        attemptedRoutes)
+                    || !routes.TryGetDistance(interactionGrid, out int distance)
                     || !routes.TryGetPath(interactionGrid, out IReadOnlyList<GridPoint> gridPath))
                     continue;
 
                 candidates.Add((
                     new HarvestChestOption(
-                        new GridPoint(chestTile.X, chestTile.Y),
+                        chestGrid,
                         new GridPoint(interaction.X, interaction.Y),
                         matchKind.Value,
                         acceptableCapacity,

--- a/HarvestingContractExecutionController.cs
+++ b/HarvestingContractExecutionController.cs
@@ -593,7 +593,8 @@ internal sealed class HarvestingContractExecutionController
     private void HandleFailedDeliveryRoute(ActiveHarvestContract contract, string reason)
     {
         Point? failedChest = contract.CurrentChestRoute?.ChestTile;
-        this.MarkCurrentChestAttempted(contract);
+        Point? failedInteraction = contract.CurrentChestRoute?.InteractionTile;
+        this.MarkCurrentChestRouteAttempted(contract);
 
         GridPoint origin = new(
             contract.Lease.Worker.TilePoint.X,
@@ -604,8 +605,9 @@ internal sealed class HarvestingContractExecutionController
         if (decision.CanReplan)
         {
             this.Monitor.Log(
-                $"Harvest delivery route from {origin} to chest {failedChest} failed ({reason}); "
-                + $"trying another eligible destination "
+                $"Harvest delivery route from {origin} to chest {failedChest} "
+                + $"through interaction {failedInteraction} failed ({reason}); "
+                + $"trying another safe interaction route "
                 + $"[{decision.FailureCount}/{decision.MaximumFailures}].",
                 LogLevel.Debug);
             this.BeginDeliveryOrReturn(contract);
@@ -615,7 +617,8 @@ internal sealed class HarvestingContractExecutionController
         this.Monitor.Log(
             $"Harvest worker '{contract.Lease.Worker.Name}' exhausted "
             + $"{decision.MaximumFailures} consecutive delivery routes from {origin}; "
-            + "stopping the contract because no classified chest remains safely reachable.",
+            + $"last chest={failedChest}, interaction={failedInteraction}; "
+            + "stopping the contract because no classified chest route remains safely reachable.",
             LogLevel.Warn);
         this.StopForUnavailableStorage(contract, "delivery route retries were exhausted");
     }
@@ -840,12 +843,15 @@ internal sealed class HarvestingContractExecutionController
 
         HarvestCargoEntry entry = contract.Cargo[0];
         HashSet<Point> attempted = contract.GetAttemptedChests(entry.TransferId);
+        HashSet<HarvestChestRouteKey> attemptedRoutes =
+            contract.GetAttemptedChestRoutes(entry.TransferId);
         HarvestChestRoute? route = this.ChestRouter.FindBestRoute(
             contract.Farm,
             contract.Lease.Worker,
             contract.Lease.Worker.TilePoint,
             entry.Item,
-            attempted);
+            attempted,
+            attemptedRoutes);
         if (route is null)
         {
             this.StopForUnavailableStorage(
@@ -2148,6 +2154,18 @@ internal sealed class HarvestingContractExecutionController
         contract.GetAttemptedChests(contract.Cargo[0].TransferId).Add(contract.CurrentChestRoute.ChestTile);
     }
 
+    private void MarkCurrentChestRouteAttempted(ActiveHarvestContract contract)
+    {
+        if (contract.CurrentChestRoute is null || contract.Cargo.Count == 0)
+            return;
+
+        HarvestChestRoute route = contract.CurrentChestRoute;
+        contract.GetAttemptedChestRoutes(contract.Cargo[0].TransferId).Add(
+            new HarvestChestRouteKey(
+                new GridPoint(route.ChestTile.X, route.ChestTile.Y),
+                new GridPoint(route.InteractionTile.X, route.InteractionTile.Y)));
+    }
+
     private void ReleaseCurrentChestLock(ActiveHarvestContract contract)
     {
         NetMutex? mutex = contract.CurrentChestRoute?.Chest.GetMutex();
@@ -2215,6 +2233,8 @@ internal sealed class HarvestingContractExecutionController
     private sealed class ActiveHarvestContract
     {
         private readonly Dictionary<string, HashSet<Point>> AttemptedChestTiles = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, HashSet<HarvestChestRouteKey>> AttemptedChestRoutes =
+            new(StringComparer.Ordinal);
 
         public ActiveHarvestContract(
             Guid id,
@@ -2289,6 +2309,19 @@ internal sealed class HarvestingContractExecutionController
             {
                 attempted = new HashSet<Point>();
                 this.AttemptedChestTiles[transferId] = attempted;
+            }
+
+            return attempted;
+        }
+
+        public HashSet<HarvestChestRouteKey> GetAttemptedChestRoutes(string transferId)
+        {
+            if (!this.AttemptedChestRoutes.TryGetValue(
+                    transferId,
+                    out HashSet<HarvestChestRouteKey>? attempted))
+            {
+                attempted = new HashSet<HarvestChestRouteKey>();
+                this.AttemptedChestRoutes[transferId] = attempted;
             }
 
             return attempted;

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -43,6 +43,7 @@ List<(string Name, Action Test)> tests = new()
     ("harvest chest full acceptance", TestHarvestChestFullAcceptance),
     ("harvest stable category destination", TestHarvestStableCategoryDestination),
     ("harvest empty chest capacity fallback", TestHarvestEmptyChestCapacityFallback),
+    ("harvest chest route attempt isolation", TestHarvestChestRouteAttemptIsolation),
     ("storage sort classification priority", TestStorageSortClassificationPriority),
     ("storage sort category purity", TestStorageSortCategoryPurity),
     ("storage sort stable tie", TestStorageSortStableTie),
@@ -775,6 +776,36 @@ static void TestHarvestEmptyChestCapacityFallback()
 
     IReadOnlyList<HarvestChestOption> ordered = HarvestChestRanking.Order(options);
     Equal(new GridPoint(8, 8), ordered[0].ChestTile);
+}
+
+static void TestHarvestChestRouteAttemptIsolation()
+{
+    GridPoint chest = new(12, 8);
+    GridPoint south = new(12, 9);
+    GridPoint west = new(11, 8);
+    HashSet<GridPoint> attemptedChests = new();
+    HashSet<HarvestChestRouteKey> attemptedRoutes = new()
+    {
+        new(chest, south)
+    };
+
+    Equal(true, HarvestChestRouteAttemptPolicy.IsExcluded(
+        chest,
+        south,
+        attemptedChests,
+        attemptedRoutes));
+    Equal(false, HarvestChestRouteAttemptPolicy.IsExcluded(
+        chest,
+        west,
+        attemptedChests,
+        attemptedRoutes));
+
+    attemptedChests.Add(chest);
+    Equal(true, HarvestChestRouteAttemptPolicy.IsExcluded(
+        chest,
+        west,
+        attemptedChests,
+        attemptedRoutes));
 }
 
 static void TestStorageSortClassificationPriority()


### PR DESCRIPTION
## Summary

- track failed harvest delivery approaches by `(chest tile, interaction tile)`
- keep alternate safe interaction tiles for the same classified chest eligible
- retain whole-chest exclusion for mutex, identity, compatibility, or capacity failures
- keep the existing three-consecutive-route retry budget and improve route diagnostics

## Verification

- `./scripts/verify-release.sh`
- 76/76 deterministic logic tests
- Release build: 0 warnings, 0 errors
- audited source tree: `5e2de6dd4954976eee4e069de64a45c512c64f92`
- package SHA-256: `c20de3024bf37a225a6d77d24b279e16b5aee022d411db113747d62cea7660d0`

## Live gate

Draft until the isolated in-game regression reproducer confirms that the worker can use another side of the same chest and harvest all remaining mature crops without losing cargo.

Closes #71
