### PR TITLE
chore(release): force publish v0.1.0

### DIFF
--- a/.github/workflows/source-validation.yml
+++ b/.github/workflows/source-validation.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          bash -n scripts/verify-release.sh
+          bash -n scripts/verify-release.sh scripts/verify-release-asset.sh
           git diff --check 4b825dc642cb6eb9a060e54bf8d69288fbee4904 HEAD
 
           jq empty manifest.json i18n/default.json i18n/zh.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.0 - Unreleased
+
 - Made harvest delivery a contract-level choice: classified chests are the manual and automatic default, requester inventory is explicit, and a running contract never silently switches between them.
 - Isolated a crop after its live interaction routes are exhausted instead of marking every remaining crop unreachable; three independently stalled crops at one origin still trigger a bounded safe return.
 - Isolated a stalled harvest chest interaction route instead of rejecting every approach to that chest, while retaining whole-chest exclusion for storage or mutex failures.

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.1.0-beta.1</Version>
+    <Version>0.1.0</Version>
     <AssemblyName>EvilFarmOwner</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Aveouter/EvilFarmOwner</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </h1>
 
 <p align="center">
-  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.1.0-beta.1
+  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.1.0
 </p>
 
 <p align="center">
@@ -29,7 +29,7 @@
 
 `Evil Farm Owner` is a Stardew Valley mod for players who want to turn repetitive farm chores into paid labor.
 
-`v0.1.0-beta.1` is the current public test release. The development branch also includes manually confirmed named chest sorting, but it is not a released or verified feature until its disposable-save acceptance gate passes. Multiplayer uses a host-authoritative protocol, while the real remote host/farmhand matrix and forced storage-recovery matrix remain explicitly unverified. Back up the save before testing and report issues with both peers' SMAPI logs.
+`v0.1.0-beta.1` remains the current public test release. This source branch prepares the stable `v0.1.0` candidate, including manually confirmed named chest sorting, but the candidate must not be merged, tagged, or published until its disposable-save sorting gate, forced storage-recovery matrix, real remote host/farmhand matrix, and final-artifact smoke test all pass. Back up the save before testing and report issues with both peers' SMAPI logs.
 
 Press one key to review only the named adult NPCs who are currently available for hire. NPCs in protected vanilla activities such as chores, exercise, scripted animation, or movement pauses are omitted instead of being interrupted. An available adult NPC can be assigned a visible watering, harvest, or manual chest-sorting contract with an itemized wage, lossless item handling, and a protected return to their original schedule position.
 
@@ -123,7 +123,7 @@ Mods/EvilFarmOwner/config.json
 
 `邪恶农场主` 是一个《星露谷物语》SMAPI Mod。它的核心玩法是：你花钱雇佣农工，把重复农活交给他们处理。
 
-`v0.1.0-beta.1` 是当前公开测试版本。开发分支还加入了手动确认的具名箱子整理，但在一次性存档验收通过前，它还不是已发布或已验证功能。多人协议采用主机权威模式，真实远程主机/农场工矩阵和强制储存恢复矩阵仍明确标记为“未验证”。测试前请备份存档；反馈问题时请同时提供两端 SMAPI 日志。
+`v0.1.0-beta.1` 仍是当前公开测试版本。本源码分支用于准备稳定版 `v0.1.0` 候选，包含手动确认的具名箱子整理；但在一次性存档整理门禁、强制储存恢复矩阵、真实远程主机/农场工矩阵和最终安装包烟雾测试全部通过前，不得合并、打标签或发布。测试前请备份存档；反馈问题时请同时提供两端 SMAPI 日志。
 
 当前名单只显示此刻可以雇佣的具名成年 NPC。正在做家务、锻炼、脚本动画或处于移动暂停等原版活动的 NPC 会直接从名单中隐藏，不会被强行中断。有空的成年 NPC 可以接受可见执行的浇水、收获或手动箱子整理合同；工资会逐项显示，物品会无损处理，NPC 完成后安全返回原位置并恢复日程。
 
@@ -168,7 +168,7 @@ K
 
 具名合同最迟必须在下午 4:00 开始，并受晚上 10:00 安全停止时间约束；同一时间只能执行一份。发布构建不提供瞬时全局工作命令：所有生产环境农场变更都必须经过具名合同。
 
-多人游戏中，主机和已连接的农场工都可以请求浇水、收获或手动箱子整理合同。农场工确认后只会向主机发送带版本的请求，本地绝不会直接改动金币、NPC、作物、货物或箱子。主机会重新检查玩家、工人、资金、作物目标或箱子计划、路线以及存档、日期和版本身份，再把已接受合同、阶段、货物与转移状态、动作和最终结果同步给其他玩家。协议 7 还会验证并保存箱子整理中已完成与已跳过的转移报告。主机会随存档保存有界请求账本和每位请求者的最近结果，重启后把它们绑定到新的网络会话；重试只返回原结果，不会重复扣钱或出工。若恢复记录不兼容、内部不一致或保存时仍有未收尾合同，模组会禁用新合同，而不是猜测恢复。箱子整理仍须通过真实远程多人验收，才能标记为已验证。
+多人游戏中，主机和已连接的农场工都可以请求浇水、收获或手动箱子整理合同。农场工确认后只会向主机发送带版本的请求，本地绝不会直接改动金币、NPC、作物、货物或箱子。主机会重新检查玩家、工人、资金、作物目标或箱子计划、路线以及存档、日期和版本身份，再把已接受合同、阶段、货物与转移状态、动作和最终结果同步给其他玩家。协议 8 还会验证并保存箱子整理中已完成与已跳过的转移报告。主机会随存档保存有界请求账本和每位请求者的最近结果，重启后把它们绑定到新的网络会话；重试只返回原结果，不会重复扣钱或出工。若恢复记录不兼容、内部不一致或保存时仍有未收尾合同，模组会禁用新合同，而不是猜测恢复。箱子整理仍须通过真实远程多人验收，才能标记为已验证。
 
 新配置默认使用 `K`。如果旧配置仍使用 `H` 且安装了 UI Info Suite 2，模组会显示冲突警告；请把 `OpenMenuKey` 改成 `K`，或使用 `efo_roster`。
 
@@ -230,7 +230,7 @@ Mods/EvilFarmOwner/config.json
 
 - Host-authoritative multiplayer is implemented but still requires the release-gate test with a real remote host/farmhand session; split-screen alone is not accepted as proof.
 - Manual named chest sorting is implemented on the development branch but still requires disposable-save single-player and real remote multiplayer acceptance; recurring sorting remains disabled.
-- This beta is not the stable `v0.1.0`; use a backed-up save until the remaining multiplayer and forced-recovery gates pass.
+- Stable `v0.1.0` publication remains blocked until the live sorting, forced-recovery, real multiplayer, and final-artifact smoke gates pass; use a backed-up save with the public beta.
 - Named watering and multi-crop harvest contracts are visible; debris cleanup, fertilizing, planting, and automatic shipping are not part of v0.1.0.
 - Every peer must install the same Evil Farm Owner version; mismatched protocol/save/day/player/task messages are rejected without mutation.
 - Named harvest supports content-classified ordinary player-owned main-farm chests. Persistent overflow is emergency preservation after a storage-triggered stop; special or modded chest subclasses are excluded for safety.

--- a/docs/RELEASE_NOTES_0.1.0.md
+++ b/docs/RELEASE_NOTES_0.1.0.md
@@ -54,3 +54,17 @@ Every multiplayer peer must install the exact same version.
 - Source tree: `{{SOURCE_TREE}}`
 - Downloaded-asset SHA-256: `{{DOWNLOADED_ZIP_SHA256}}`
 - License: MIT
+
+After publishing, download the public asset into an otherwise clean directory
+and run:
+
+```bash
+./scripts/verify-release-asset.sh \
+  "EvilFarmOwner 0.1.0.zip" \
+  "{{ZIP_SHA256}}" \
+  "0.1.0"
+```
+
+The command must pass against the downloaded bytes before the release Issue is
+closed. It verifies the filename, checksum, package allowlist, embedded manifest,
+license, and absence of development-only or acceptance-test commands.

--- a/docs/RELEASE_NOTES_0.1.0.md
+++ b/docs/RELEASE_NOTES_0.1.0.md
@@ -1,15 +1,19 @@
 # Evil Farm Owner v0.1.0
 
-> **Stable release candidate / 稳定版候选**
+> **Maintainer-forced stable release / 维护者强制正式发布**
 >
-> Do not publish this candidate until the linked single-player sorting, forced
-> storage-recovery, real two-process multiplayer, and final packaged-artifact
-> smoke gates are complete. Replace the integrity placeholders only with hashes
-> from the audited merge commit and the asset downloaded from GitHub Releases.
+> The maintainer explicitly authorized publishing v0.1.0 before every manual
+> gate was complete. Deterministic source checks, tests, a clean Release build,
+> package allowlist verification, and a downloaded-asset checksum audit still
+> must pass. Forced storage-recovery scenarios B/C, real two-process
+> multiplayer, and the final in-game exact-artifact smoke test remain
+> unverified. This is an explicit release-risk acceptance, not evidence that
+> those gates passed.
 >
-> 在具名单机箱子整理、强制储存恢复、真实双进程多人及最终发布包烟雾门禁全部
-> 完成前，不得发布此候选。完整性占位符只能替换为审计后合并提交生成、并从
-> GitHub Releases 回下载验证的实际值。
+> 维护者已明确授权在全部人工门禁完成前发布 v0.1.0。确定性源码检查、测试、
+> 干净 Release 构建、发布包白名单校验和回下载哈希审计仍必须通过。强制储存
+> 恢复场景 B/C、真实双进程多人及最终游戏内精确发布包烟雾测试仍未验证。
+> 这是明确接受发布风险，不代表这些门禁已经通过。
 
 ## 中文
 
@@ -49,22 +53,13 @@ Every multiplayer peer must install the exact same version.
 ## Integrity / 完整性
 
 - Asset: `EvilFarmOwner 0.1.0.zip`
-- SHA-256: `{{ZIP_SHA256}}`
-- Source commit: `{{SOURCE_COMMIT}}`
-- Source tree: `{{SOURCE_TREE}}`
-- Downloaded-asset SHA-256: `{{DOWNLOADED_ZIP_SHA256}}`
+- SHA-256: recorded in the published GitHub Release after upload and download verification.
+- Source commit and tree: recorded in the published GitHub Release.
+- Downloaded-asset SHA-256: must exactly match the uploaded-asset SHA-256.
 - License: MIT
 
 After publishing, download the public asset into an otherwise clean directory
-and run:
-
-```bash
-./scripts/verify-release-asset.sh \
-  "EvilFarmOwner 0.1.0.zip" \
-  "{{ZIP_SHA256}}" \
-  "0.1.0"
-```
-
-The command must pass against the downloaded bytes before the release Issue is
-closed. It verifies the filename, checksum, package allowlist, embedded manifest,
-license, and absence of development-only or acceptance-test commands.
+and run `scripts/verify-release-asset.sh` with the checksum recorded in the
+GitHub Release. The command verifies the filename, checksum, package allowlist,
+embedded manifest, license, and absence of development-only or acceptance-test
+commands.

--- a/docs/RELEASE_NOTES_0.1.0.md
+++ b/docs/RELEASE_NOTES_0.1.0.md
@@ -1,0 +1,56 @@
+# Evil Farm Owner v0.1.0
+
+> **Stable release candidate / 稳定版候选**
+>
+> Do not publish this candidate until the linked single-player sorting, forced
+> storage-recovery, real two-process multiplayer, and final packaged-artifact
+> smoke gates are complete. Replace the integrity placeholders only with hashes
+> from the audited merge commit and the asset downloaded from GitHub Releases.
+>
+> 在具名单机箱子整理、强制储存恢复、真实双进程多人及最终发布包烟雾门禁全部
+> 完成前，不得发布此候选。完整性占位符只能替换为审计后合并提交生成、并从
+> GitHub Releases 回下载验证的实际值。
+
+## 中文
+
+- 从当前安全可雇佣的成年 NPC 中选择工人，查看好感度、时薪、六小时授权上限与休息日三倍工资。
+- 让具名工人从真实农场边界入口进入，在不破坏摆件的前提下完成全部可到达的浇水或收获目标并安全返回。
+- 为每份收获合同固定选择“分类箱”或“请求者背包”，合同执行期间绝不随机切换目的地。
+- 按“同品质可堆叠、同物品、同 `Item.Category`、空箱”确定性分类收获物，并在没有完整堆叠容量时安全停止。
+- 手动雇佣具名 NPC 执行不可变箱子整理计划；完整堆叠只在同时验证来源箱、目标箱及双锁后移动一次。
+- 通过持久溢出仓、可见掉落、隔离仓与恢复记录守恒已经取得所有权的货物，绝不自动出售或静默删除。
+- 主机和农场工都可请求合同；只有主机修改作物、金币、NPC、货物和箱子。协议 8 提供幂等请求、阶段快照、重连及主机重启恢复。
+- 支持一份主机专用自动合同授权，包含固定候选池、每日幂等选择、预算上限和休息日显式授权；自动箱子整理仍未开放。
+
+安装：解压 ZIP，把 `EvilFarmOwner` 文件夹放入 Stardew Valley 的 `Mods`
+目录。要求 Stardew Valley 1.6+、SMAPI 4.0+；所有联机玩家必须安装完全
+相同的版本。
+
+## English
+
+- Choose a currently safe adult NPC and review friendship, hourly wage, the six-hour authorization cap, and explicit rest-day triple pay.
+- Named workers enter through genuine farm-boundary entrances, avoid placed objects, complete every reachable watering or harvest target, and return safely.
+- Fix each harvest contract to either classified chests or the requester inventory; a running contract never switches destination silently.
+- Classify harvest output deterministically by compatible quality stack, same item, exact `Item.Category`, then empty chest, and stop safely when no destination can accept the whole stack.
+- Hire a named NPC to execute one immutable chest-sorting plan; a whole stack moves exactly once only after both source and destination chests and locks are verified.
+- Conserve owned cargo through persistent overflow, visible drop, quarantine inventory, or a recovery record; never auto-ship or silently delete it.
+- Hosts and farmhands can request contracts while only the host mutates crops, money, NPCs, cargo, and chests. Protocol 8 provides idempotent requests, phase snapshots, reconnect synchronization, and host-restart recovery.
+- Configure one host-owned automatic authorization with a fixed candidate pool, once-per-day deterministic selection, hard wage caps, and explicit rest-day opt-in; automatic chest sorting remains unavailable.
+
+Install by extracting the ZIP and placing the `EvilFarmOwner` folder in Stardew
+Valley's `Mods` directory. Stardew Valley 1.6+ and SMAPI 4.0+ are required.
+Every multiplayer peer must install the exact same version.
+
+## Known limitations / 已知限制
+
+- Debris clearing, planting, fertilizing, automatic shipping, automatic chest sorting, and special/modded chest support are not included.
+- Every multiplayer peer must use exactly the same mod version.
+
+## Integrity / 完整性
+
+- Asset: `EvilFarmOwner 0.1.0.zip`
+- SHA-256: `{{ZIP_SHA256}}`
+- Source commit: `{{SOURCE_COMMIT}}`
+- Source tree: `{{SOURCE_TREE}}`
+- Downloaded-asset SHA-256: `{{DOWNLOADED_ZIP_SHA256}}`
+- License: MIT

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "Name": "Evil Farm Owner",
   "Author": "Aveouter",
-  "Version": "0.1.0-beta.1",
-  "Description": "Hire named adult NPCs for visible watering and lossless harvest contracts.",
+  "Version": "0.1.0",
+  "Description": "Hire named adult NPCs for visible watering, lossless harvest, and deterministic chest sorting.",
   "UniqueID": "Aveouter.EvilFarmOwner",
   "EntryDll": "EvilFarmOwner.dll",
   "MinimumApiVersion": "4.0.0",

--- a/scripts/verify-release-asset.sh
+++ b/scripts/verify-release-asset.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 3 ]]; then
+  echo "Usage: $0 <downloaded-zip> <expected-sha256> <stable-version>" >&2
+  exit 2
+fi
+
+asset_path="$1"
+expected_sha256="$(printf '%s' "$2" | LC_ALL=C tr 'A-F' 'a-f')"
+expected_version="$3"
+
+if [[ ! -f "$asset_path" ]]; then
+  echo "Downloaded release asset does not exist: $asset_path" >&2
+  exit 1
+fi
+if [[ ! "$expected_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Expected SHA-256 must contain exactly 64 hexadecimal characters." >&2
+  exit 2
+fi
+if [[ ! "$expected_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Release asset audit requires a stable semantic version without a prerelease suffix." >&2
+  exit 2
+fi
+
+expected_name="EvilFarmOwner $expected_version.zip"
+if [[ "$(basename "$asset_path")" != "$expected_name" ]]; then
+  echo "Release asset name must be '$expected_name'." >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha256="$(sha256sum "$asset_path" | awk '{print $1}')"
+else
+  actual_sha256="$(shasum -a 256 "$asset_path" | awk '{print $1}')"
+fi
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+  echo "Downloaded asset SHA-256 mismatch." >&2
+  echo "Expected: $expected_sha256" >&2
+  echo "Actual:   $actual_sha256" >&2
+  exit 1
+fi
+
+expected_entries=$'EvilFarmOwner/EvilFarmOwner.dll\nEvilFarmOwner/LICENSE\nEvilFarmOwner/assets/banner-v4-lowres.png\nEvilFarmOwner/assets/icon-v2.png\nEvilFarmOwner/i18n/default.json\nEvilFarmOwner/i18n/zh.json\nEvilFarmOwner/manifest.json'
+actual_entries="$(unzip -Z1 "$asset_path" | LC_ALL=C sort)"
+if [[ "$actual_entries" != "$expected_entries" ]]; then
+  echo "Downloaded release contents differ from the package allowlist:" >&2
+  diff -u <(printf '%s\n' "$expected_entries") <(printf '%s\n' "$actual_entries") || true
+  exit 1
+fi
+
+unzip -p "$asset_path" EvilFarmOwner/manifest.json \
+  | jq -e --arg version "$expected_version" '
+      .Name == "Evil Farm Owner"
+      and .Author == "Aveouter"
+      and .Version == $version
+      and .UniqueID == "Aveouter.EvilFarmOwner"
+      and .EntryDll == "EvilFarmOwner.dll"
+      and (.UpdateKeys | index("GitHub:Aveouter/EvilFarmOwner") != null)
+    ' >/dev/null
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if ! cmp -s "$project_root/LICENSE" <(unzip -p "$asset_path" EvilFarmOwner/LICENSE); then
+  echo "Downloaded LICENSE differs from the reviewed repository license." >&2
+  exit 1
+fi
+
+dll_search_text="$(
+  unzip -p "$asset_path" EvilFarmOwner/EvilFarmOwner.dll \
+    | LC_ALL=C tr -d '\000'
+)"
+if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_faults|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
+  echo "Downloaded DLL exposes a legacy prototype or acceptance-test command/setting." >&2
+  exit 1
+fi
+
+echo "Verified downloaded asset: $asset_path"
+echo "Verified stable version: $expected_version"
+echo "Verified SHA-256: $actual_sha256"
+echo "Downloaded release asset verification passed."


### PR DESCRIPTION
## Summary

- prepare the stable `0.1.0` project and manifest version;
- add bilingual stable release notes and downloaded-asset verification;
- correct the Chinese README chest-sorting wire version from protocol 7 to protocol 8;
- record the maintainer's explicit force-release authorization.

## Maintainer override

The maintainer explicitly instructed the project to force-publish v0.1.0. This overrides the previously required manual gates, but does not mark them as passed.

Still unverified at publication time:

- forced storage-recovery scenarios B/C;
- real two-process host/farmhand acceptance;
- final in-game smoke test using the exact published artifact.

The deterministic source checks, test suite, clean Release build, package allowlist, production-DLL scan, GitHub upload, public re-download, and SHA-256 audit remain mandatory.

## Existing verification

- 81/81 deterministic tests on the stable candidate before the documentation-only override;
- Release build: 0 warnings, 0 errors;
- strict format, JSON, version alignment, translation parity, manifest, license, and package allowlist checks passed;
- no game production Mods deployment;
- no acceptance-test code is included in the production build.

Final source, tree, DLL, ZIP, and downloaded-asset hashes will be recorded in the published GitHub Release.