### PR TITLE
fix(release): accept GitHub-normalized asset name

### DIFF
--- a/docs/RELEASE_NOTES_0.1.0.md
+++ b/docs/RELEASE_NOTES_0.1.0.md
@@ -52,7 +52,7 @@ Every multiplayer peer must install the exact same version.
 
 ## Integrity / 完整性
 
-- Asset: `EvilFarmOwner 0.1.0.zip`
+- GitHub asset: `EvilFarmOwner.0.1.0.zip` (the local build output uses spaces; GitHub normalizes them to dots).
 - SHA-256: recorded in the published GitHub Release after upload and download verification.
 - Source commit and tree: recorded in the published GitHub Release.
 - Downloaded-asset SHA-256: must exactly match the uploaded-asset SHA-256.
@@ -60,6 +60,7 @@ Every multiplayer peer must install the exact same version.
 
 After publishing, download the public asset into an otherwise clean directory
 and run `scripts/verify-release-asset.sh` with the checksum recorded in the
-GitHub Release. The command verifies the filename, checksum, package allowlist,
-embedded manifest, license, and absence of development-only or acceptance-test
-commands.
+GitHub Release. The verifier accepts both the local space-separated build name
+and GitHub's normalized dotted download name, and verifies the checksum, package
+allowlist, embedded manifest, license, and absence of development-only or
+acceptance-test commands.

--- a/scripts/verify-release-asset.sh
+++ b/scripts/verify-release-asset.sh
@@ -23,9 +23,11 @@ if [[ ! "$expected_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 2
 fi
 
-expected_name="EvilFarmOwner $expected_version.zip"
-if [[ "$(basename "$asset_path")" != "$expected_name" ]]; then
-  echo "Release asset name must be '$expected_name'." >&2
+local_build_name="EvilFarmOwner $expected_version.zip"
+github_asset_name="EvilFarmOwner.$expected_version.zip"
+actual_name="$(basename "$asset_path")"
+if [[ "$actual_name" != "$local_build_name" && "$actual_name" != "$github_asset_name" ]]; then
+  echo "Release asset name must be '$local_build_name' locally or '$github_asset_name' after GitHub normalization." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- accept the local build name `EvilFarmOwner 0.1.0.zip`;
- also accept GitHub's normalized download name `EvilFarmOwner.0.1.0.zip`;
- document the normalization in the stable release notes.

No gameplay, manifest, binary, or package-content changes.

## Verification

- the current draft asset was uploaded successfully and GitHub reported SHA-256 `02b1303d91adf20c0321c21be95e89880458a7f370971b9d301117d3052ed724`;
- source validation must pass before merge;
- the corrected verifier will run against the public re-download before publication.