### PR TITLE
feat(shift): reconcile work before settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added one bounded final reconciliation pass across harvest, watering, and chest sorting before a complete shift settles, so work that becomes ready during the initial pass is checked once without allowing an infinite loop.
 - Replaced manual task selection with one complete farm-work shift per hire: harvest ready crops and tappers, water dry crops, then sort ordinary farm chests, skipping empty stages.
 - Reused one NPC lease, one six-hour wage reservation, one harvest destination, and one final settlement across the whole shift; recurring hiring now uses the same behavior.
 - Upgraded the host-authoritative multiplayer protocol to version 9 and migrated valid legacy automatic watering/harvest authorizations to complete farm work without raising their saved wage caps.

--- a/src/FarmWorkContractExecutionController.cs
+++ b/src/FarmWorkContractExecutionController.cs
@@ -185,7 +185,10 @@ internal sealed class FarmWorkContractExecutionController
         return stage with
         {
             Task = NamedFarmTask.FarmWork,
-            Phase = $"{shift.CurrentStage}/{stage.Phase}",
+            Phase = FarmWorkPassPolicy.FormatRuntimePhase(
+                shift.CurrentStage,
+                shift.CurrentPass,
+                stage.Phase),
             ReservedGold = shift.Context.BillingPreview.MaximumAuthorizedWage,
             StartTime = shift.Context.Lease.StartTime,
             CompletedWork = shift.StageCompletions.Sum(result => result.CompletedWork) + stage.CompletedWork
@@ -237,6 +240,17 @@ internal sealed class FarmWorkContractExecutionController
 
             shift.LastFinishedStage = stage;
             stage = FarmWorkStagePolicy.GetNext(stage);
+        }
+
+        if (FarmWorkPassPolicy.TryGetNext(shift.CurrentPass, out FarmWorkPass nextPass))
+        {
+            shift.CurrentPass = nextPass;
+            shift.LastFinishedStage = null;
+            this.Monitor.Log(
+                $"Farm-work shift {shift.Context.Id:N} is starting its bounded reconciliation pass.",
+                LogLevel.Debug);
+            this.BeginNextAvailableStage(shift);
+            return;
         }
 
         bool completedAnyWork = shift.StageCompletions.Any(result => result.CompletedWork > 0);
@@ -377,6 +391,7 @@ internal sealed class FarmWorkContractExecutionController
         public FarmWorkShiftContext Context { get; }
         public List<NamedContractCompletionState> StageCompletions { get; } = new();
         public FarmWorkStage CurrentStage { get; set; } = FarmWorkStage.Harvesting;
+        public FarmWorkPass CurrentPass { get; set; } = FarmWorkPass.Initial;
         public FarmWorkStage? LastFinishedStage { get; set; }
         public bool Dispatched { get; set; }
         public bool Finalizing { get; set; }

--- a/src/FarmWorkShift.cs
+++ b/src/FarmWorkShift.cs
@@ -10,6 +10,12 @@ internal enum FarmWorkStage
     Complete
 }
 
+internal enum FarmWorkPass
+{
+    Initial,
+    Reconciliation
+}
+
 internal sealed record FarmWorkShiftContext(
     Guid Id,
     string RequestId,
@@ -50,5 +56,36 @@ internal static class FarmWorkStagePolicy
                 or "storage-sort.start.no-chest",
             _ => false
         };
+    }
+}
+
+internal static class FarmWorkPassPolicy
+{
+    public const int MaximumPasses = 2;
+
+    public static IReadOnlyList<(FarmWorkPass Pass, FarmWorkStage Stage)> OrderedSteps { get; } =
+        new[] { FarmWorkPass.Initial, FarmWorkPass.Reconciliation }
+            .SelectMany(pass => FarmWorkStagePolicy.Order.Select(stage => (pass, stage)))
+            .ToArray();
+
+    public static bool TryGetNext(FarmWorkPass current, out FarmWorkPass next)
+    {
+        if (current == FarmWorkPass.Initial)
+        {
+            next = FarmWorkPass.Reconciliation;
+            return true;
+        }
+
+        next = current;
+        return false;
+    }
+
+    public static string FormatRuntimePhase(
+        FarmWorkStage stage,
+        FarmWorkPass pass,
+        string childPhase)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(childPhase);
+        return $"{stage}/{pass}/{childPhase}";
     }
 }

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -227,6 +227,35 @@ static void TestFarmWorkStageOrder()
     Equal(false, FarmWorkStagePolicy.IsEmptyStageFailure(
         FarmWorkStage.Harvesting,
         "harvest.start.no-reachable-crop"));
+
+    Equal(FarmWorkPassPolicy.MaximumPasses, 2);
+    Equal(true, FarmWorkPassPolicy.TryGetNext(
+        FarmWorkPass.Initial,
+        out FarmWorkPass reconciliation));
+    Equal(FarmWorkPass.Reconciliation, reconciliation);
+    Equal(false, FarmWorkPassPolicy.TryGetNext(
+        FarmWorkPass.Reconciliation,
+        out FarmWorkPass terminal));
+    Equal(FarmWorkPass.Reconciliation, terminal);
+    Equal(6, FarmWorkPassPolicy.OrderedSteps.Count);
+    Equal(
+        (FarmWorkPass.Initial, FarmWorkStage.Harvesting),
+        FarmWorkPassPolicy.OrderedSteps[0]);
+    Equal(
+        (FarmWorkPass.Initial, FarmWorkStage.StorageSorting),
+        FarmWorkPassPolicy.OrderedSteps[2]);
+    Equal(
+        (FarmWorkPass.Reconciliation, FarmWorkStage.Harvesting),
+        FarmWorkPassPolicy.OrderedSteps[3]);
+    Equal(
+        (FarmWorkPass.Reconciliation, FarmWorkStage.StorageSorting),
+        FarmWorkPassPolicy.OrderedSteps[5]);
+    Equal(
+        "Watering/Reconciliation/Acting",
+        FarmWorkPassPolicy.FormatRuntimePhase(
+            FarmWorkStage.Watering,
+            FarmWorkPass.Reconciliation,
+            "Acting"));
 }
 
 static void TestRecurringContractStateValidation()


### PR DESCRIPTION
Closes #84

## What changed
- run one bounded reconciliation pass after the initial harvest → watering → chest-sorting pass
- rescan all supported domains in the same deterministic order and skip empty stages
- keep the same NPC lease, wage reservation, destination, request identity, and final settlement
- expose initial/reconciliation phase identity in host-authoritative runtime snapshots without breaking remote action rendering
- cap the shift at exactly two passes to prevent infinite rescans

## Safety
- completed world mutations are not replayed; each existing stage rescans live eligible state
- any non-empty-stage failure remains fail-closed
- hard stop, day end, save boundary, lease restoration, item recovery, and aggregate accounting remain unchanged

## Verification
- Release build with deployment and ZIP disabled: 0 warnings, 0 errors
- deterministic logic suite: 84/84 passed
- no game launch or Mods deployment