### PR TITLE
fix(build): restore .NET 6 phase validation

### DIFF
--- a/src/FarmWorkShift.cs
+++ b/src/FarmWorkShift.cs
@@ -85,7 +85,13 @@ internal static class FarmWorkPassPolicy
         FarmWorkPass pass,
         string childPhase)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(childPhase);
+        if (string.IsNullOrWhiteSpace(childPhase))
+        {
+            throw new ArgumentException(
+                "Child phase is required.",
+                nameof(childPhase));
+        }
+
         return $"{stage}/{pass}/{childPhase}";
     }
 }

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -256,6 +256,10 @@ static void TestFarmWorkStageOrder()
             FarmWorkStage.Watering,
             FarmWorkPass.Reconciliation,
             "Acting"));
+    Throws<ArgumentException>(() => FarmWorkPassPolicy.FormatRuntimePhase(
+        FarmWorkStage.Harvesting,
+        FarmWorkPass.Initial,
+        " "));
 }
 
 static void TestRecurringContractStateValidation()
@@ -2560,4 +2564,20 @@ static void Equal<T>(T expected, T actual, [CallerLineNumber] int line = 0)
 {
     if (!EqualityComparer<T>.Default.Equals(expected, actual))
         throw new InvalidOperationException($"line={line}, expected={expected}, actual={actual}");
+}
+
+static void Throws<TException>(Action action, [CallerLineNumber] int line = 0)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException(
+        $"line={line}, expected exception={typeof(TException).Name}");
 }


### PR DESCRIPTION
Closes #91

## Summary
- replace the unsupported validation API with an explicit .NET 6-compatible guard
- add deterministic coverage for blank runtime phases

## Verification
- `dotnet build -c Release --no-restore -p:EnableModDeploy=false -p:EnableModZip=false`
- `dotnet run --project tests/EvilFarmOwner.LogicTests.csproj -c Release --no-restore` (84 tests)