### PR TITLE
feat(harvest): collect ready fruit trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added lossless collection of all ready fruit-tree fruit, including vanilla coal conversion for lightning-struck trees.
 - Added one bounded final reconciliation pass across harvest, watering, and chest sorting before a complete shift settles, so work that becomes ready during the initial pass is checked once without allowing an infinite loop.
 - Replaced manual task selection with one complete farm-work shift per hire: harvest ready crops and tappers, water dry crops, then sort ordinary farm chests, skipping empty stages.
 - Reused one NPC lease, one six-hour wage reservation, one harvest destination, and one final settlement across the whole shift; recurring hiring now uses the same behavior.

--- a/docs/HARVEST_SOURCE_MATRIX.md
+++ b/docs/HARVEST_SOURCE_MATRIX.md
@@ -1,0 +1,30 @@
+# Harvest Source Matrix
+
+This matrix prevents the complete shift from treating every object with a held item as the same kind of harvest source. Each source is enabled only after its vanilla collection state, ownership, follow-up triggers, and replay behavior are represented explicitly.
+
+## Enabled
+
+| Source | Vanilla state transition preserved | Item handling |
+| --- | --- | --- |
+| Mature crops | `Crop.harvest` and crop removal/regrowth result | Exact captured output and by-products enter the lossless destination pipeline. |
+| Normal and heavy tree tappers | Clear ready output, then call the tree's tapper rescheduler | Exact output enters the lossless destination pipeline; rollback restores the ready item if rescheduling fails. |
+| Fruit trees | Clear the tree's fruit list once after capturing every non-null fruit slot | Stored item, stack, and quality are preserved. Lightning-struck trees produce one coal per occupied fruit slot like vanilla. |
+
+## Requires a dedicated implementation
+
+| Source | Why generic `heldObject` removal is unsafe |
+| --- | --- |
+| Data-driven machines, including bee houses, mushroom boxes/logs, lightning rods, solar panels, statues, and similar producers | Vanilla collection can recalculate output, update stats and experience, reset sprites, run `OutputCollected` rules, or start another output. Each enabled machine must preserve those rules while deliberately avoiding automatic refill. |
+| Crab pots | Collection clears bait/readiness, records caught fish, applies profession/book effects, grants fishing experience, and may change stack size. Refill remains a separate future action. |
+| Fish ponds | Collection clears the building output and grants fishing experience based on value. The interaction tile and building-owned output need a building-target route. |
+| Berry and tea bushes | Output count, quality, experience, mutex behavior, and special walnut bushes depend on bush type and the requesting farmer. Special/map bushes must be excluded explicitly. |
+| Farm-building interiors | Barns, coops, sheds, caves, and greenhouse-like locations need location-aware entrances, doors, route ownership, and return behavior before their contents can join a main-farm shift. |
+| Loose forage and spawned objects | Ownership, quest/special items, spawned-object flags, and terrain coverage need an allowlist. Debris clearing is not harvest collection. |
+
+## Excluded by policy
+
+- Shipping-bin collection or automatic sale.
+- Automatic machine refill or consumption of player inputs.
+- Auto-grabber contents; those belong to the animal-care/storage design and require the chest mutex.
+- Incubators, hatching devices, quest rewards, choice menus, buffs, arcade/furniture interactions, and other non-item interactions.
+- Modded machines without an explicit compatibility contract.

--- a/src/ContractHarvestCollector.cs
+++ b/src/ContractHarvestCollector.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.Characters;
+using StardewValley.TerrainFeatures;
 
 namespace EvilFarmOwner;
 
@@ -43,5 +44,23 @@ internal static class TapperHarvestSemantics
         bool readyForHarvest)
     {
         return isTapper && attachedToTree && hasOutput && readyForHarvest;
+    }
+}
+
+internal static class FruitTreeHarvestSemantics
+{
+    public static bool IsReadyTarget(
+        int growthStage,
+        bool isStump,
+        int fruitSlots)
+    {
+        return growthStage >= FruitTree.treeStage
+            && !isStump
+            && fruitSlots > 0;
+    }
+
+    public static bool ProducesCoal(bool struckByLightning)
+    {
+        return struckByLightning;
     }
 }

--- a/src/HarvestTargetPlanner.cs
+++ b/src/HarvestTargetPlanner.cs
@@ -18,7 +18,8 @@ internal enum HarvestPlanFailure
 internal enum HarvestTargetKind
 {
     Crop,
-    Tapper
+    Tapper,
+    FruitTree
 }
 
 internal sealed record HarvestTargetPlan(
@@ -251,12 +252,27 @@ internal sealed class HarvestTargetPlanner
             readyForHarvest);
     }
 
+    public static bool IsReadySupportedFruitTree(GameLocation location, Vector2 tile)
+    {
+        if (!location.terrainFeatures.TryGetValue(tile, out TerrainFeature? feature)
+            || feature is not FruitTree tree)
+            return false;
+
+        int fruitSlots = tree.fruit.Count(item => item is not null);
+        return FruitTreeHarvestSemantics.IsReadyTarget(
+            tree.growthStage.Value,
+            tree.stump.Value,
+            fruitSlots);
+    }
+
     public static HarvestTargetKind? GetSupportedTargetKind(GameLocation location, Vector2 tile)
     {
         if (IsMatureSupportedCrop(location, tile))
             return HarvestTargetKind.Crop;
         if (IsReadySupportedTapper(location, tile))
             return HarvestTargetKind.Tapper;
+        if (IsReadySupportedFruitTree(location, tile))
+            return HarvestTargetKind.FruitTree;
         return null;
     }
 

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -892,6 +892,7 @@ internal sealed class HarvestingContractExecutionController
         {
             HarvestTargetKind.Crop => this.TryApplyCropHarvest(contract),
             HarvestTargetKind.Tapper => this.TryApplyTapperHarvest(contract),
+            HarvestTargetKind.FruitTree => this.TryApplyFruitTreeHarvest(contract),
             _ => false
         };
     }
@@ -958,6 +959,43 @@ internal sealed class HarvestingContractExecutionController
 
         this.CaptureHarvestItem(contract, collected, "tapper");
         this.ShowHarvestedItem(contract, collected);
+        return true;
+    }
+
+    private bool TryApplyFruitTreeHarvest(ActiveHarvestContract contract)
+    {
+        Vector2 targetTile = new(contract.CurrentTarget.TargetTile.X, contract.CurrentTarget.TargetTile.Y);
+        if (!HarvestTargetPlanner.IsReadySupportedFruitTree(contract.Farm, targetTile)
+            || !contract.Farm.terrainFeatures.TryGetValue(targetTile, out TerrainFeature? feature)
+            || feature is not FruitTree tree)
+            return false;
+
+        bool producesCoal = FruitTreeHarvestSemantics.ProducesCoal(
+            tree.struckByLightningCountdown.Value > 0);
+        List<Item> collected = new();
+        foreach (Item? fruit in tree.fruit)
+        {
+            if (fruit is null)
+                continue;
+
+            if (producesCoal)
+            {
+                collected.Add(ItemRegistry.Create("(O)382"));
+                continue;
+            }
+
+            Item exactFruit = fruit.getOne();
+            exactFruit.Stack = fruit.Stack;
+            collected.Add(exactFruit);
+        }
+
+        if (collected.Count == 0)
+            return false;
+
+        tree.fruit.Clear();
+        foreach (Item item in collected)
+            this.CaptureHarvestItem(contract, item, producesCoal ? "lightning-struck fruit tree" : "fruit tree");
+        this.ShowHarvestedItem(contract, collected[0]);
         return true;
     }
 

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -69,6 +69,7 @@ List<(string Name, Action Test)> tests = new()
     ("harvest chest release deferral", TestHarvestChestReleaseDeferral),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("ready tapper target semantics", TestReadyTapperTargetSemantics),
+    ("ready fruit-tree target semantics", TestReadyFruitTreeTargetSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
     ("harvest transfer replay protection", TestHarvestTransferReplayProtection),
     ("harvest placement conservation", TestHarvestPlacementConservation),
@@ -1635,6 +1636,32 @@ static void TestReadyTapperTargetSemantics()
     Equal(false, TapperHarvestSemantics.IsReadyTarget(true, false, true, true));
     Equal(false, TapperHarvestSemantics.IsReadyTarget(true, true, false, true));
     Equal(false, TapperHarvestSemantics.IsReadyTarget(true, true, true, false));
+}
+
+static void TestReadyFruitTreeTargetSemantics()
+{
+    Equal(true, FruitTreeHarvestSemantics.IsReadyTarget(
+        growthStage: 4,
+        isStump: false,
+        fruitSlots: 1));
+    Equal(true, FruitTreeHarvestSemantics.IsReadyTarget(
+        growthStage: 4,
+        isStump: false,
+        fruitSlots: 3));
+    Equal(false, FruitTreeHarvestSemantics.IsReadyTarget(
+        growthStage: 3,
+        isStump: false,
+        fruitSlots: 1));
+    Equal(false, FruitTreeHarvestSemantics.IsReadyTarget(
+        growthStage: 4,
+        isStump: true,
+        fruitSlots: 1));
+    Equal(false, FruitTreeHarvestSemantics.IsReadyTarget(
+        growthStage: 4,
+        isStump: false,
+        fruitSlots: 0));
+    Equal(false, FruitTreeHarvestSemantics.ProducesCoal(struckByLightning: false));
+    Equal(true, FruitTreeHarvestSemantics.ProducesCoal(struckByLightning: true));
 }
 
 static void TestHarvestPlacementConservation()


### PR DESCRIPTION
Refs #85

## Summary
- add ready fruit trees to complete-shift harvest planning
- preserve each stored fruit item, stack, and quality through the lossless destination pipeline
- match vanilla lightning-struck fruit trees by collecting one coal per occupied fruit slot
- document which farm-product sources are enabled, deferred for dedicated semantics, or excluded

## Verification
- `dotnet build -c Release --no-restore -p:EnableModDeploy=false -p:EnableModZip=false`
- `dotnet run --project tests/EvilFarmOwner.LogicTests.csproj -c Release --no-restore` (85 tests)