### PR TITLE
design(workforce): reserve deterministic scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reserved deterministic multi-worker scheduling with stable target identities, exclusive host-owned claims, efficiency-aware partitioning, and checked per-worker wage aggregation; concurrent dispatch remains disabled pending runtime safety coverage.
 - Added lossless collection of all ready fruit-tree fruit, including vanilla coal conversion for lightning-struck trees.
 - Added one bounded final reconciliation pass across harvest, watering, and chest sorting before a complete shift settles, so work that becomes ready during the initial pass is checked once without allowing an infinite loop.
 - Replaced manual task selection with one complete farm-work shift per hire: harvest ready crops and tappers, water dry crops, then sort ordinary farm chests, skipping empty stages.

--- a/docs/MULTI_WORKER_ARCHITECTURE.md
+++ b/docs/MULTI_WORKER_ARCHITECTURE.md
@@ -1,0 +1,25 @@
+# Multi-worker architecture boundary
+
+The complete shift remains limited to one active worker for now. New work should nevertheless use the model below so concurrent hiring can be enabled later without changing target ownership or billing rules.
+
+## Stable work and deterministic scheduling
+
+- A target is identified by domain, location, and a source-specific stable ID. Coordinates alone are insufficient for animals, buildings, and movable objects.
+- The host sorts targets and workers by ordinal stable IDs, then assigns each target to the worker with the lowest projected efficiency-adjusted load. Ties use worker ID.
+- A one-worker shift uses the same partitioner and is therefore the one-element form of the future system.
+
+## Claim lifecycle
+
+1. An available target can be claimed by exactly one worker.
+2. A successful world mutation commits the claim before later storage or presentation work.
+3. If a worker leaves or fails, only that worker's uncommitted claims are released.
+4. Committed claims remain in the ledger and must never be replayed.
+5. Final reconciliation creates or claims only targets that are still available.
+
+The host owns this ledger. Multiplayer messages will carry shift, assignment, worker, target, and sequence identities; peers render snapshots but do not mutate work state.
+
+## Independent worker state
+
+Each assignment will own its NPC lease, route controller, tool/cargo state, availability result, wage authorization, elapsed-time settlement, and recovery path. Storage remains protected by the existing ordered chest locks. A worker failure cannot release another worker's lock or lease.
+
+The shift report contains per-worker authorization and charge records plus a checked aggregate total. Concurrent dispatch stays disabled until runtime save/reconnect, route collision, storage lock, and settlement coverage is complete.

--- a/src/WorkforceScheduling.cs
+++ b/src/WorkforceScheduling.cs
@@ -1,0 +1,168 @@
+namespace EvilFarmOwner;
+
+internal sealed record WorkTargetIdentity(
+    string Domain,
+    string Location,
+    string TargetId)
+{
+    public string StableKey => $"{this.Domain}\u001f{this.Location}\u001f{this.TargetId}";
+}
+
+internal sealed record SchedulableWorkTarget(
+    WorkTargetIdentity Identity,
+    int EstimatedCost);
+
+internal sealed record SchedulableWorker(
+    string WorkerId,
+    decimal EfficiencyMultiplier);
+
+internal sealed record WorkerTargetAssignment(
+    string WorkerId,
+    IReadOnlyList<WorkTargetIdentity> Targets,
+    decimal EstimatedLoad);
+
+internal static class DeterministicWorkforceScheduler
+{
+    public static IReadOnlyList<WorkerTargetAssignment> Partition(
+        IEnumerable<SchedulableWorker> workers,
+        IEnumerable<SchedulableWorkTarget> targets)
+    {
+        ArgumentNullException.ThrowIfNull(workers);
+        ArgumentNullException.ThrowIfNull(targets);
+
+        SchedulableWorker[] orderedWorkers = workers
+            .OrderBy(worker => worker.WorkerId, StringComparer.Ordinal)
+            .ToArray();
+        SchedulableWorkTarget[] orderedTargets = targets
+            .OrderBy(target => target.Identity.StableKey, StringComparer.Ordinal)
+            .ToArray();
+
+        if (orderedWorkers.Length == 0 && orderedTargets.Length > 0)
+            throw new InvalidOperationException("Work targets require at least one worker.");
+        if (orderedWorkers.Any(worker => string.IsNullOrWhiteSpace(worker.WorkerId)
+            || worker.EfficiencyMultiplier <= 0m))
+            throw new ArgumentException("Every worker requires an ID and positive efficiency.", nameof(workers));
+        if (orderedWorkers.Select(worker => worker.WorkerId).Distinct(StringComparer.Ordinal).Count()
+            != orderedWorkers.Length)
+            throw new ArgumentException("Worker IDs must be unique.", nameof(workers));
+        if (orderedTargets.Any(target => target.EstimatedCost <= 0
+            || string.IsNullOrWhiteSpace(target.Identity.Domain)
+            || string.IsNullOrWhiteSpace(target.Identity.Location)
+            || string.IsNullOrWhiteSpace(target.Identity.TargetId)))
+            throw new ArgumentException("Every target requires a stable identity and positive cost.", nameof(targets));
+        if (orderedTargets.Select(target => target.Identity.StableKey).Distinct(StringComparer.Ordinal).Count()
+            != orderedTargets.Length)
+            throw new ArgumentException("Target identities must be unique.", nameof(targets));
+
+        Dictionary<string, List<WorkTargetIdentity>> assignments = orderedWorkers
+            .ToDictionary(worker => worker.WorkerId, _ => new List<WorkTargetIdentity>(), StringComparer.Ordinal);
+        Dictionary<string, decimal> loads = orderedWorkers
+            .ToDictionary(worker => worker.WorkerId, _ => 0m, StringComparer.Ordinal);
+
+        foreach (SchedulableWorkTarget target in orderedTargets)
+        {
+            SchedulableWorker selected = orderedWorkers
+                .OrderBy(worker => loads[worker.WorkerId]
+                    + target.EstimatedCost / worker.EfficiencyMultiplier)
+                .ThenBy(worker => worker.WorkerId, StringComparer.Ordinal)
+                .First();
+            decimal adjustedCost = target.EstimatedCost / selected.EfficiencyMultiplier;
+            assignments[selected.WorkerId].Add(target.Identity);
+            loads[selected.WorkerId] += adjustedCost;
+        }
+
+        return orderedWorkers
+            .Select(worker => new WorkerTargetAssignment(
+                worker.WorkerId,
+                assignments[worker.WorkerId].ToArray(),
+                loads[worker.WorkerId]))
+            .ToArray();
+    }
+}
+
+internal enum WorkClaimState
+{
+    Claimed,
+    Committed
+}
+
+internal sealed record WorkClaimSnapshot(
+    WorkTargetIdentity Target,
+    string WorkerId,
+    WorkClaimState State);
+
+internal sealed class DeterministicWorkClaimLedger
+{
+    private readonly Dictionary<string, WorkClaimSnapshot> Claims = new(StringComparer.Ordinal);
+
+    public bool IsClaimed(WorkTargetIdentity target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return this.Claims.ContainsKey(target.StableKey);
+    }
+
+    public bool TryClaim(WorkTargetIdentity target, string workerId)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        if (string.IsNullOrWhiteSpace(workerId))
+            throw new ArgumentException("Worker ID is required.", nameof(workerId));
+
+        if (this.Claims.ContainsKey(target.StableKey))
+            return false;
+
+        this.Claims[target.StableKey] = new(target, workerId, WorkClaimState.Claimed);
+        return true;
+    }
+
+    public bool TryCommit(WorkTargetIdentity target, string workerId)
+    {
+        if (!this.Claims.TryGetValue(target.StableKey, out WorkClaimSnapshot? claim)
+            || claim.WorkerId != workerId
+            || claim.State != WorkClaimState.Claimed)
+            return false;
+
+        this.Claims[target.StableKey] = claim with { State = WorkClaimState.Committed };
+        return true;
+    }
+
+    public int ReleaseUncommitted(string workerId)
+    {
+        string[] releasable = this.Claims.Values
+            .Where(claim => claim.WorkerId == workerId && claim.State == WorkClaimState.Claimed)
+            .Select(claim => claim.Target.StableKey)
+            .ToArray();
+        foreach (string key in releasable)
+            this.Claims.Remove(key);
+        return releasable.Length;
+    }
+
+    public IReadOnlyList<WorkClaimSnapshot> Snapshot()
+    {
+        return this.Claims.Values
+            .OrderBy(claim => claim.Target.StableKey, StringComparer.Ordinal)
+            .ToArray();
+    }
+}
+
+internal sealed record WorkerWageSettlement(string WorkerId, int AuthorizedGold, int ChargedGold);
+
+internal static class WorkforceSettlementPolicy
+{
+    public static int GetAggregateCharge(IEnumerable<WorkerWageSettlement> settlements)
+    {
+        ArgumentNullException.ThrowIfNull(settlements);
+        int total = 0;
+        HashSet<string> workers = new(StringComparer.Ordinal);
+        foreach (WorkerWageSettlement settlement in settlements)
+        {
+            if (string.IsNullOrWhiteSpace(settlement.WorkerId)
+                || !workers.Add(settlement.WorkerId)
+                || settlement.AuthorizedGold < 0
+                || settlement.ChargedGold < 0
+                || settlement.ChargedGold > settlement.AuthorizedGold)
+                throw new ArgumentException("Invalid per-worker settlement.", nameof(settlements));
+            total = checked(total + settlement.ChargedGold);
+        }
+        return total;
+    }
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -13,6 +13,10 @@ List<(string Name, Action Test)> tests = new()
     ("worker efficiency timing", TestWorkerEfficiencyTiming),
     ("worker efficiency contract snapshot", TestWorkerEfficiencyContractSnapshot),
     ("farm-work stage order", TestFarmWorkStageOrder),
+    ("deterministic workforce partition", TestDeterministicWorkforcePartition),
+    ("workforce claim ownership", TestWorkforceClaimOwnership),
+    ("workforce final reconciliation", TestWorkforceFinalReconciliation),
+    ("workforce settlement aggregation", TestWorkforceSettlementAggregation),
     ("recurring contract state validation", TestRecurringContractStateValidation),
     ("recurring contract candidate pool", TestRecurringContractCandidatePool),
     ("recurring contract ranking", TestRecurringContractRanking),
@@ -261,6 +265,96 @@ static void TestFarmWorkStageOrder()
         FarmWorkStage.Harvesting,
         FarmWorkPass.Initial,
         " "));
+}
+
+static void TestDeterministicWorkforcePartition()
+{
+    SchedulableWorker[] workers =
+    {
+        new("Leah", 1m),
+        new("Alex", 2m)
+    };
+    SchedulableWorkTarget[] targets =
+    {
+        new(new("Harvest", "Farm", "C"), 10),
+        new(new("Harvest", "Farm", "A"), 10),
+        new(new("Water", "Farm", "B"), 10)
+    };
+
+    IReadOnlyList<WorkerTargetAssignment> first =
+        DeterministicWorkforceScheduler.Partition(workers, targets);
+    IReadOnlyList<WorkerTargetAssignment> second =
+        DeterministicWorkforceScheduler.Partition(workers.Reverse(), targets.Reverse());
+
+    Equal("Alex", first[0].WorkerId);
+    Equal("Leah", first[1].WorkerId);
+    Equal(string.Join(",", first[0].Targets.Select(target => target.TargetId)),
+        string.Join(",", second[0].Targets.Select(target => target.TargetId)));
+    Equal(string.Join(",", first[1].Targets.Select(target => target.TargetId)),
+        string.Join(",", second[1].Targets.Select(target => target.TargetId)));
+    Equal(3, first.Sum(assignment => assignment.Targets.Count));
+
+    IReadOnlyList<WorkerTargetAssignment> single =
+        DeterministicWorkforceScheduler.Partition(new[] { workers[0] }, targets);
+    Equal(3, single[0].Targets.Count);
+}
+
+static void TestWorkforceClaimOwnership()
+{
+    WorkTargetIdentity first = new("Harvest", "Farm", "crop-1");
+    WorkTargetIdentity second = new("Water", "Farm", "crop-2");
+    DeterministicWorkClaimLedger ledger = new();
+
+    Equal(true, ledger.TryClaim(first, "Alex"));
+    Equal(false, ledger.TryClaim(first, "Leah"));
+    Equal(true, ledger.TryCommit(first, "Alex"));
+    Equal(true, ledger.TryClaim(second, "Alex"));
+    Equal(1, ledger.ReleaseUncommitted("Alex"));
+    Equal(1, ledger.Snapshot().Count);
+    Equal(WorkClaimState.Committed, ledger.Snapshot()[0].State);
+    Equal(false, ledger.TryClaim(first, "Leah"));
+    Equal(true, ledger.TryClaim(second, "Leah"));
+}
+
+static void TestWorkforceFinalReconciliation()
+{
+    WorkTargetIdentity committed = new("Harvest", "Farm", "crop-1");
+    WorkTargetIdentity interrupted = new("Water", "Farm", "crop-2");
+    DeterministicWorkClaimLedger ledger = new();
+    Equal(true, ledger.TryClaim(committed, "Alex"));
+    Equal(true, ledger.TryCommit(committed, "Alex"));
+    Equal(true, ledger.TryClaim(interrupted, "Alex"));
+    Equal(1, ledger.ReleaseUncommitted("Alex"));
+
+    SchedulableWorkTarget[] discovered =
+    {
+        new(committed, 10),
+        new(interrupted, 10)
+    };
+    SchedulableWorkTarget[] available = discovered
+        .Where(target => !ledger.IsClaimed(target.Identity))
+        .ToArray();
+    IReadOnlyList<WorkerTargetAssignment> reconciled =
+        DeterministicWorkforceScheduler.Partition(
+            new[] { new SchedulableWorker("Leah", 1m) },
+            available);
+
+    Equal(1, reconciled[0].Targets.Count);
+    Equal("crop-2", reconciled[0].Targets[0].TargetId);
+}
+
+static void TestWorkforceSettlementAggregation()
+{
+    Equal(900, WorkforceSettlementPolicy.GetAggregateCharge(new[]
+    {
+        new WorkerWageSettlement("Alex", 700, 600),
+        new WorkerWageSettlement("Leah", 400, 300)
+    }));
+    Throws<ArgumentException>(() => WorkforceSettlementPolicy.GetAggregateCharge(new[]
+    {
+        new WorkerWageSettlement("Alex", 700, 600),
+        new WorkerWageSettlement("Alex", 400, 300)
+    }));
 }
 
 static void TestRecurringContractStateValidation()


### PR DESCRIPTION
Closes #87

## Summary
- define stable domain/location/target identities and deterministic efficiency-aware partitioning
- add an exclusive host-owned claim lifecycle where worker failure releases only uncommitted work
- validate per-worker wage records and checked aggregate settlement
- document the runtime boundary that keeps concurrent dispatch disabled until its safety gates pass

## Verification
- `dotnet build -c Release --no-restore -p:EnableModDeploy=false -p:EnableModZip=false`
- `dotnet run --project tests/EvilFarmOwner.LogicTests.csproj -c Release --no-restore` (89 tests)