### PR TITLE
feat(animals): define safe care semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Reserved deterministic multi-worker scheduling with stable target identities, exclusive host-owned claims, efficiency-aware partitioning, and checked per-worker wage aggregation; concurrent dispatch remains disabled pending runtime safety coverage.
+- Defined the vanilla-safe eligibility and conservation rules for daily petting, finite-hay feeding, loose animal products, and tool-harvested milk/wool before animal care joins complete shifts.
 - Added lossless collection of all ready fruit-tree fruit, including vanilla coal conversion for lightning-struck trees.
 - Added one bounded final reconciliation pass across harvest, watering, and chest sorting before a complete shift settles, so work that becomes ready during the initial pass is checked once without allowing an infinite loop.
 - Replaced manual task selection with one complete farm-work shift per hire: harvest ready crops and tappers, water dry crops, then sort ordinary farm chests, skipping empty stages.

--- a/docs/ANIMAL_OPERATION_MATRIX.md
+++ b/docs/ANIMAL_OPERATION_MATRIX.md
@@ -1,0 +1,20 @@
+# Vanilla animal-operation matrix
+
+Animal care will become a complete-shift stage only after each row below has a location-aware route, stable identity, host-owned mutation, commit check, and recovery path. This matrix records the vanilla state that must be preserved.
+
+| Operation | Eligibility | Required state transition | Product/storage rule |
+| --- | --- | --- | --- |
+| Pet | Host, awake animal, `wasPet == false` | Use the normal manual-pet effects once, including the reduced gain after auto-petting, mood/friendship caps, profession effects, farming XP, texture/emote state, and `wasPet` | No item output. A repeated or replayed target is skipped. |
+| Fill trough | Empty map tile marked `Trough`; owned silo hay is available | Consume exactly one owned hay before adding exactly one hay object; stop when either capacity or hay reaches zero | Never create hay, take hay from player inventory implicitly, replace an occupied tile, or exceed valid trough capacity. |
+| Loose overnight product | Object is in an animal-house location and its qualified ID is allowlisted by a resident animal's drop-over-night produce data | Remove one stable location/tile/object target only after cargo recovery is established | Route the exact item, stack, and quality through the shift destination. Never collect placed machines, furniture, quest items, or auto-grabber contents. |
+| Milk or shear | Host; adult; non-null `currentProduce`; harvest type is `HarvestWithTool`; animal data names a tool; auto-grabber does not own the product | Create the configured product with stored quality and cracker stack, then preserve vanilla stats, clear `currentProduce`, add 5 friendship, reload texture, and grant 5 farming XP | The tool name is semantic input; the player does not need to own or equip a pail/shears. Clear produce only after the exact output has entered the recovery pipeline. |
+| Dig-up product | Produced as a loose outdoor object by the animal | No direct animal mutation during collection | Later handled by a narrowly allowlisted loose-product collector; ordinary forage and player-placed objects remain excluded. |
+| Auto-grabber | Machine owns its internal chest and collection timing | No mutation by the animal-care stage | Excluded. Sorting auto-grabber contents requires a separate locked-container design. |
+
+## Location and door boundary
+
+- A target key includes operation, building/location identity, animal ID or tile/object identity, and day.
+- Animals are handled in their actual current location; an outdoor animal is not teleported home for convenience.
+- Entering barns/coops requires a real building transition and an independently planned return path. Ordinary doors may be opened when allowed, but no farm object is destroyed.
+- Sleeping, pregnancy/birth, festivals/events, unavailable interiors, and location changes cause an explicit skip or replan, never a blind mutation.
+- Final reconciliation may discover an unclaimed target once more. A committed animal/day or product identity is never repeated.

--- a/src/AnimalCarePolicy.cs
+++ b/src/AnimalCarePolicy.cs
@@ -1,0 +1,90 @@
+namespace EvilFarmOwner;
+
+internal enum AnimalCareSkipReason
+{
+    None,
+    NotHost,
+    AlreadyPet,
+    Sleeping,
+    Baby,
+    NoProduce,
+    WrongHarvestType,
+    MissingHarvestTool,
+    AutoGrabberOwned
+}
+
+internal sealed record AnimalProducePlan(
+    string QualifiedItemId,
+    int Stack,
+    int Quality,
+    string RequiredTool);
+
+internal static class AnimalPettingPolicy
+{
+    public static AnimalCareSkipReason GetSkipReason(
+        bool isHost,
+        bool wasPet,
+        bool isSleeping)
+    {
+        if (!isHost)
+            return AnimalCareSkipReason.NotHost;
+        if (wasPet)
+            return AnimalCareSkipReason.AlreadyPet;
+        if (isSleeping)
+            return AnimalCareSkipReason.Sleeping;
+        return AnimalCareSkipReason.None;
+    }
+}
+
+internal static class AnimalFeedingPolicy
+{
+    public static int GetFillCount(int emptyTroughTiles, int ownedHay)
+    {
+        if (emptyTroughTiles < 0)
+            throw new ArgumentOutOfRangeException(nameof(emptyTroughTiles));
+        if (ownedHay < 0)
+            throw new ArgumentOutOfRangeException(nameof(ownedHay));
+        return Math.Min(emptyTroughTiles, ownedHay);
+    }
+}
+
+internal static class AnimalProducePolicy
+{
+    public static AnimalCareSkipReason TryCreateToolHarvestPlan(
+        bool isHost,
+        bool isAdult,
+        string? currentProduceId,
+        bool harvestsWithTool,
+        string? harvestTool,
+        bool hasEatenAnimalCracker,
+        int quality,
+        bool autoGrabberOwnsProduce,
+        out AnimalProducePlan? plan)
+    {
+        plan = null;
+        if (!isHost)
+            return AnimalCareSkipReason.NotHost;
+        if (autoGrabberOwnsProduce)
+            return AnimalCareSkipReason.AutoGrabberOwned;
+        if (!isAdult)
+            return AnimalCareSkipReason.Baby;
+        if (string.IsNullOrWhiteSpace(currentProduceId))
+            return AnimalCareSkipReason.NoProduce;
+        if (!harvestsWithTool)
+            return AnimalCareSkipReason.WrongHarvestType;
+        if (string.IsNullOrWhiteSpace(harvestTool))
+            return AnimalCareSkipReason.MissingHarvestTool;
+        if (quality < 0)
+            throw new ArgumentOutOfRangeException(nameof(quality));
+
+        string qualifiedId = currentProduceId.StartsWith("(", StringComparison.Ordinal)
+            ? currentProduceId
+            : $"(O){currentProduceId}";
+        plan = new AnimalProducePlan(
+            qualifiedId,
+            hasEatenAnimalCracker ? 2 : 1,
+            quality,
+            harvestTool);
+        return AnimalCareSkipReason.None;
+    }
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -17,6 +17,9 @@ List<(string Name, Action Test)> tests = new()
     ("workforce claim ownership", TestWorkforceClaimOwnership),
     ("workforce final reconciliation", TestWorkforceFinalReconciliation),
     ("workforce settlement aggregation", TestWorkforceSettlementAggregation),
+    ("animal petting idempotency", TestAnimalPettingIdempotency),
+    ("animal finite hay conservation", TestAnimalFiniteHayConservation),
+    ("animal tool produce readiness", TestAnimalToolProduceReadiness),
     ("recurring contract state validation", TestRecurringContractStateValidation),
     ("recurring contract candidate pool", TestRecurringContractCandidatePool),
     ("recurring contract ranking", TestRecurringContractRanking),
@@ -355,6 +358,47 @@ static void TestWorkforceSettlementAggregation()
         new WorkerWageSettlement("Alex", 700, 600),
         new WorkerWageSettlement("Alex", 400, 300)
     }));
+}
+
+static void TestAnimalPettingIdempotency()
+{
+    Equal(AnimalCareSkipReason.None,
+        AnimalPettingPolicy.GetSkipReason(true, false, false));
+    Equal(AnimalCareSkipReason.AlreadyPet,
+        AnimalPettingPolicy.GetSkipReason(true, true, false));
+    Equal(AnimalCareSkipReason.Sleeping,
+        AnimalPettingPolicy.GetSkipReason(true, false, true));
+    Equal(AnimalCareSkipReason.NotHost,
+        AnimalPettingPolicy.GetSkipReason(false, false, false));
+}
+
+static void TestAnimalFiniteHayConservation()
+{
+    Equal(0, AnimalFeedingPolicy.GetFillCount(0, 20));
+    Equal(2, AnimalFeedingPolicy.GetFillCount(8, 2));
+    Equal(8, AnimalFeedingPolicy.GetFillCount(8, 20));
+    Throws<ArgumentOutOfRangeException>(() => AnimalFeedingPolicy.GetFillCount(1, -1));
+}
+
+static void TestAnimalToolProduceReadiness()
+{
+    AnimalCareSkipReason ready = AnimalProducePolicy.TryCreateToolHarvestPlan(
+        true, true, "184", true, "Milk Pail", true, 2, false,
+        out AnimalProducePlan? plan);
+    Equal(AnimalCareSkipReason.None, ready);
+    Equal("(O)184", plan!.QualifiedItemId);
+    Equal(2, plan.Stack);
+    Equal(2, plan.Quality);
+    Equal("Milk Pail", plan.RequiredTool);
+
+    Equal(AnimalCareSkipReason.Baby, AnimalProducePolicy.TryCreateToolHarvestPlan(
+        true, false, "184", true, "Milk Pail", false, 0, false, out _));
+    Equal(AnimalCareSkipReason.NoProduce, AnimalProducePolicy.TryCreateToolHarvestPlan(
+        true, true, null, true, "Milk Pail", false, 0, false, out _));
+    Equal(AnimalCareSkipReason.WrongHarvestType, AnimalProducePolicy.TryCreateToolHarvestPlan(
+        true, true, "184", false, "Milk Pail", false, 0, false, out _));
+    Equal(AnimalCareSkipReason.AutoGrabberOwned, AnimalProducePolicy.TryCreateToolHarvestPlan(
+        true, true, "184", true, "Milk Pail", false, 0, true, out _));
 }
 
 static void TestRecurringContractStateValidation()


### PR DESCRIPTION
Refs #86

## Summary
- document vanilla state transitions and ownership boundaries for petting, trough feeding, loose products, milk/shearing, dig-up products, and auto-grabbers
- add host-only idempotent petting eligibility
- add finite-hay conservation and exact milk/wool output planning, including animal-cracker stacks and stored quality
- keep the runtime animal-care stage disabled until location routing and commit/recovery are implemented

## Verification
- `dotnet build -c Release --no-restore -p:EnableModDeploy=false -p:EnableModZip=false`
- `dotnet run --project tests/EvilFarmOwner.LogicTests.csproj -c Release --no-restore` (92 tests)