### PR TITLE
feat(animals): enter houses and fill troughs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added safe barn/coop human-door transitions, indoor animal petting, and finite-silo-hay trough feeding to complete shifts.
 - Added host-owned, non-destructive outdoor animal petting to complete shifts, with stable animal identities, daily idempotency, worker movement, and final reconciliation.
 - Reserved deterministic multi-worker scheduling with stable target identities, exclusive host-owned claims, efficiency-aware partitioning, and checked per-worker wage aggregation; concurrent dispatch remains disabled pending runtime safety coverage.
 - Defined the vanilla-safe eligibility and conservation rules for daily petting, finite-hay feeding, loose animal products, and tool-harvested milk/wool before animal care joins complete shifts.

--- a/docs/ANIMAL_OPERATION_MATRIX.md
+++ b/docs/ANIMAL_OPERATION_MATRIX.md
@@ -1,6 +1,6 @@
 # Vanilla animal-operation matrix
 
-Outdoor main-farm petting now participates in complete shifts with stable animal IDs, host-owned mutation, non-destructive routes, and final reconciliation. Barn/coop interiors and the remaining rows stay disabled until each has a location-aware route, commit check, and recovery path. This matrix records the vanilla state that must be preserved.
+Outdoor and barn/coop petting now participate in complete shifts with stable animal IDs, host-owned mutation, non-destructive routes, and final reconciliation. Workers use each building's human door and original interior warp, then return through the same entrance. Empty troughs are filled one at a time from real silo hay with rollback on placement failure. Product rows stay disabled until each has a commit check and lossless recovery path.
 
 | Operation | Eligibility | Required state transition | Product/storage rule |
 | --- | --- | --- | --- |

--- a/i18n/default.json
+++ b/i18n/default.json
@@ -154,7 +154,7 @@
   "contract.confirm.rest-day.farm-work": "Authorize triple pay · all farm work",
   "farm-work.start.too-late": "Complete farm-work shifts must start by 4:00 PM.",
   "farm-work.start.no-work": "There is no supported harvest, watering, animal-petting, or chest-sorting work ready on the main farm.",
-  "animal-care.start.no-work": "There are no awake, unpetted animals outdoors on the main farm.",
+  "animal-care.start.no-work": "There are no awake, unpetted animals or empty troughs available for this shift.",
   "farm-work.hud.completed": "{{worker}} completed the farm-work shift: {{stages}} active stage(s), {{work}} action(s). Paid {{paid}}g / {{hours}}h; refunded {{refunded}}g.",
   "farm-work.hud.stopped": "{{worker}} stopped the farm-work shift: {{reason}} Completed {{stages}} stage(s), {{work}} action(s). Paid {{paid}}g / {{hours}}h; refunded {{refunded}}g.",
   "contract.start.host-only": "Only the host player can start an NPC work contract.",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -154,7 +154,7 @@
   "contract.confirm.rest-day.farm-work": "授权三倍工资并完成全部农活",
   "farm-work.start.too-late": "完整农活班次最迟必须在下午 4:00 开始。",
   "farm-work.start.no-work": "主农场当前没有可执行的收获、浇水、牲畜抚摸或箱子整理工作。",
-  "animal-care.start.no-work": "主农场室外没有清醒且今天尚未抚摸的牲畜。",
+  "animal-care.start.no-work": "当前没有清醒且尚未抚摸的牲畜，也没有可处理的空食槽。",
   "farm-work.hud.completed": "{{worker}} 已完成农活班次：执行 {{stages}} 个有效阶段，共 {{work}} 次动作；{{hours}} 小时实付 {{paid}}g，退还 {{refunded}}g。",
   "farm-work.hud.stopped": "{{worker}} 已停止农活班次：{{reason}} 已完成 {{stages}} 个阶段、{{work}} 次动作；{{hours}} 小时实付 {{paid}}g，退还 {{refunded}}g。",
   "contract.start.host-only": "只有主机玩家可以开始 NPC 工作合同。",

--- a/src/AnimalCareContractExecutionController.cs
+++ b/src/AnimalCareContractExecutionController.cs
@@ -14,6 +14,8 @@ internal sealed class AnimalCareContractExecutionController
     private const int MaximumTravelTicks = 3600;
     private readonly IMonitor Monitor;
     private readonly AnimalPettingTargetPlanner Planner;
+    private readonly AnimalHouseRoutePlanner HousePlanner;
+    private readonly AnimalFeedingTargetPlanner FeedingPlanner;
     private ActiveAnimalCareStage? ActiveStage;
     private NamedContractCompletionState? LastCompletion;
 
@@ -21,6 +23,8 @@ internal sealed class AnimalCareContractExecutionController
     {
         this.Monitor = monitor;
         this.Planner = new AnimalPettingTargetPlanner(monitor);
+        this.HousePlanner = new AnimalHouseRoutePlanner(monitor);
+        this.FeedingPlanner = new AnimalFeedingTargetPlanner(monitor);
     }
 
     public string? LastStartFailureKey { get; private set; }
@@ -33,8 +37,16 @@ internal sealed class AnimalCareContractExecutionController
 
         Farm farm = Game1.getFarm();
         AnimalPettingWorkPlan? plan = this.Planner.TryCreate(farm, shift.Lease.Worker);
-        if (plan is null)
+        AnimalHouseWorkPlan? housePlan = plan is null
+            ? this.HousePlanner.TryCreate(farm, shift.Lease.Worker)
+            : null;
+        if (plan is null && housePlan is null)
             return this.FailStart("animal-care.start.no-work");
+
+        plan ??= new AnimalPettingWorkPlan(
+            housePlan!.ArrivalTile,
+            housePlan.ArrivalSide,
+            FirstTarget: null);
 
         ActiveAnimalCareStage stage = new(shift, farm, plan);
         this.ActiveStage = stage;
@@ -48,7 +60,10 @@ internal sealed class AnimalCareContractExecutionController
                 || worker.TilePoint != plan.ArrivalTile)
                 throw new InvalidOperationException("Worker did not arrive at the animal-care entrance.");
             worker.Halt();
-            this.BeginTravel(stage, plan.FirstTarget);
+            if (plan.FirstTarget is not null)
+                this.BeginTravel(stage, plan.FirstTarget);
+            else
+                this.BeginTravelToHouse(stage, housePlan!.FirstHouse);
             return true;
         }
         catch (Exception ex)
@@ -82,18 +97,64 @@ internal sealed class AnimalCareContractExecutionController
                     this.Complete(stage, false, "contract.failure.controller-conflict");
                     return;
                 }
-                if (this.TryFinishTravel(stage, stage.CurrentTarget.InteractionTile, this.OnArrivedAtAnimal))
+                if (this.TryFinishTravel(stage, GetCurrentInteractionTile(stage), this.OnArrivedAtWork))
                     return;
                 if (stage.PhaseTicks > MaximumTravelTicks || stage.Context.Lease.Worker.controller is null)
                     this.SkipCurrentAndContinue(stage);
+                break;
+            case AnimalCarePhase.TravelingToBuilding:
+                if (this.HasControllerConflict(stage))
+                    return;
+                if (this.TryFinishTravel(
+                        stage,
+                        stage.CurrentHouseRoute!.ExteriorInteractionTile,
+                        this.OnArrivedAtBuilding))
+                    return;
+                if (stage.PhaseTicks > MaximumTravelTicks
+                    || stage.Context.Lease.Worker.controller is null)
+                {
+                    stage.VisitedBuildingIds.Add(stage.CurrentHouseRoute!.BuildingId);
+                    stage.CurrentHouseRoute = null;
+                    this.BeginNextOrReturn(stage);
+                }
+                break;
+            case AnimalCarePhase.TravelingToHouseExit:
+                if (this.HasControllerConflict(stage))
+                    return;
+                if (this.TryFinishTravel(
+                        stage,
+                        stage.CurrentHouseRoute!.InteriorEntryTile,
+                        this.OnArrivedAtHouseExit))
+                    return;
+                if (stage.PhaseTicks > MaximumTravelTicks
+                    || stage.Context.Lease.Worker.controller is null)
+                    this.Complete(stage, false, "contract.failure.return-unreachable");
                 break;
             case AnimalCarePhase.Acting:
                 if (!stage.ActionApplied && stage.PhaseTicks >= ActionStartTicks)
                 {
                     stage.ActionApplied = true;
-                    stage.AttemptedAnimalIds.Add(stage.CurrentTarget.AnimalId);
-                    if (this.TryPetAnimal(stage))
-                        stage.PettedAnimals++;
+                    if (stage.CurrentFeedingTarget is { } feeding)
+                    {
+                        stage.AttemptedTroughTiles.Add(feeding.TargetTile);
+                        try
+                        {
+                            if (this.TryFeedTrough(stage, feeding))
+                                stage.FilledTroughs++;
+                        }
+                        catch (Exception ex)
+                        {
+                            this.Monitor.Log($"Animal feeding failed closed: {ex}", LogLevel.Error);
+                            this.Complete(stage, false, "contract.failure.target-invalidated");
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        stage.AttemptedAnimalIds.Add(stage.CurrentTarget!.AnimalId);
+                        if (this.TryPetAnimal(stage))
+                            stage.PettedAnimals++;
+                    }
                 }
                 if (stage.PhaseTicks >= ActionDurationTicks)
                     this.BeginNextOrReturn(stage);
@@ -126,9 +187,9 @@ internal sealed class AnimalCareContractExecutionController
             stage.Context.Requester.UniqueMultiplayerID, stage.Context.Lease.Worker.Name,
             NamedFarmTask.FarmWork, stage.Context.BillingPreview.EfficiencyMultiplier,
             stage.Phase.ToString(), stage.Plan.ArrivalTile.X, stage.Plan.ArrivalTile.Y,
-            stage.Plan.ArrivalSide, 0, stage.CurrentTarget.TargetTile.X,
-            stage.CurrentTarget.TargetTile.Y, stage.Context.BillingPreview.MaximumAuthorizedWage,
-            stage.Context.Lease.StartTime, stage.PettedAnimals,
+            stage.Plan.ArrivalSide, 0, stage.CurrentTarget?.TargetTile.X ?? stage.Plan.ArrivalTile.X,
+            stage.CurrentTarget?.TargetTile.Y ?? stage.Plan.ArrivalTile.Y, stage.Context.BillingPreview.MaximumAuthorizedWage,
+            stage.Context.Lease.StartTime, stage.PettedAnimals + stage.FilledTroughs,
             Array.Empty<NamedContractCargoState>(), Array.Empty<string>());
     }
 
@@ -153,39 +214,43 @@ internal sealed class AnimalCareContractExecutionController
     private void BeginTravel(ActiveAnimalCareStage stage, AnimalPettingTargetPlan target)
     {
         stage.CurrentTarget = target;
+        stage.CurrentFeedingTarget = null;
         stage.ActionApplied = false;
         stage.Phase = AnimalCarePhase.Traveling;
         stage.PhaseTicks = 0;
         NPC worker = stage.Context.Lease.Worker;
         if (worker.TilePoint == target.InteractionTile)
         {
-            this.OnArrivedAtAnimal(worker, stage.Farm);
+            this.OnArrivedAtWork(worker, stage.WorkLocation);
             return;
         }
         if (!FarmNavigationMap.CanBeginPath(
-                stage.Farm, worker, worker.TilePoint, target.Path, out string failure))
+                stage.WorkLocation, worker, worker.TilePoint, target.Path, out string failure))
             throw new InvalidOperationException($"Animal-care first step is unsafe: {failure}.");
         stage.Controller = this.CreateController(stage, target.Path, target.InteractionTile,
-            target.FacingDirection, this.OnArrivedAtAnimal);
+            target.FacingDirection, this.OnArrivedAtWork);
         stage.Context.Lease.AttachController(stage.Controller);
     }
 
-    private void OnArrivedAtAnimal(Character character, GameLocation location)
+    private void OnArrivedAtWork(Character character, GameLocation location)
     {
         if (this.ActiveStage is not { } stage
             || !ReferenceEquals(character, stage.Context.Lease.Worker)
-            || !ReferenceEquals(location, stage.Farm))
+            || !ReferenceEquals(location, stage.WorkLocation))
             return;
         stage.Phase = AnimalCarePhase.Acting;
         stage.PhaseTicks = 0;
         stage.Context.Lease.Worker.Halt();
-        stage.Context.Lease.Worker.faceDirection(stage.CurrentTarget.FacingDirection);
+        stage.Context.Lease.Worker.faceDirection(
+            stage.CurrentFeedingTarget?.FacingDirection
+                ?? stage.CurrentTarget!.FacingDirection);
     }
 
     private bool TryPetAnimal(ActiveAnimalCareStage stage)
     {
-        if (!stage.Farm.animals.TryGetValue(stage.CurrentTarget.AnimalId, out FarmAnimal? animal)
-            || !ReferenceEquals(animal.currentLocation, stage.Farm)
+        if (stage.CurrentTarget is null
+            || !stage.WorkLocation.animals.TryGetValue(stage.CurrentTarget.AnimalId, out FarmAnimal? animal)
+            || !ReferenceEquals(animal.currentLocation, stage.WorkLocation)
             || Math.Abs(animal.TilePoint.X - stage.Context.Lease.Worker.TilePoint.X)
                 + Math.Abs(animal.TilePoint.Y - stage.Context.Lease.Worker.TilePoint.Y) != 1
             || AnimalPettingPolicy.GetSkipReason(true, animal.wasPet.Value, Game1.timeOfDay >= 1900)
@@ -220,7 +285,10 @@ internal sealed class AnimalCareContractExecutionController
 
     private void SkipCurrentAndContinue(ActiveAnimalCareStage stage)
     {
-        stage.AttemptedAnimalIds.Add(stage.CurrentTarget.AnimalId);
+        if (stage.CurrentFeedingTarget is { } feeding)
+            stage.AttemptedTroughTiles.Add(feeding.TargetTile);
+        else
+            stage.AttemptedAnimalIds.Add(stage.CurrentTarget!.AnimalId);
         stage.Context.Lease.Worker.controller = null;
         stage.Controller = null;
         this.BeginNextOrReturn(stage);
@@ -228,8 +296,33 @@ internal sealed class AnimalCareContractExecutionController
 
     private void BeginNextOrReturn(ActiveAnimalCareStage stage)
     {
+        if (stage.WorkLocation is AnimalHouse house)
+        {
+            AnimalFeedingTargetPlan? feeding = this.FeedingPlanner.TryFindNext(
+                house,
+                stage.Context.Lease.Worker,
+                stage.Context.Lease.Worker.TilePoint,
+                stage.AttemptedTroughTiles);
+            if (feeding is not null)
+            {
+                try
+                {
+                    this.BeginFeedingTravel(stage, feeding);
+                }
+                catch (Exception ex)
+                {
+                    this.Monitor.Log(
+                        $"Animal-feeding route to {feeding.TargetTile} failed: {ex.Message}",
+                        LogLevel.Warn);
+                    stage.AttemptedTroughTiles.Add(feeding.TargetTile);
+                    this.BeginNextOrReturn(stage);
+                }
+                return;
+            }
+        }
+
         AnimalPettingTargetPlan? next = this.Planner.TryFindNext(
-            stage.Farm, stage.Context.Lease.Worker,
+            stage.WorkLocation, stage.Context.Lease.Worker,
             stage.Context.Lease.Worker.TilePoint, stage.AttemptedAnimalIds);
         if (next is not null)
         {
@@ -247,6 +340,15 @@ internal sealed class AnimalCareContractExecutionController
             }
             return;
         }
+
+        if (stage.WorkLocation is AnimalHouse)
+        {
+            this.BeginExitHouse(stage);
+            return;
+        }
+
+        if (this.TryBeginNextHouse(stage))
+            return;
 
         Stack<Point>? path = this.Planner.TryCreateReturnPath(
             stage.Farm, stage.Context.Lease.Worker, stage.Plan.ArrivalTile);
@@ -282,11 +384,71 @@ internal sealed class AnimalCareContractExecutionController
         }
     }
 
+    private void BeginFeedingTravel(
+        ActiveAnimalCareStage stage,
+        AnimalFeedingTargetPlan target)
+    {
+        stage.CurrentTarget = null;
+        stage.CurrentFeedingTarget = target;
+        stage.ActionApplied = false;
+        stage.Phase = AnimalCarePhase.Traveling;
+        stage.PhaseTicks = 0;
+        NPC worker = stage.Context.Lease.Worker;
+        if (worker.TilePoint == target.InteractionTile)
+        {
+            this.OnArrivedAtWork(worker, stage.WorkLocation);
+            return;
+        }
+        if (!FarmNavigationMap.CanBeginPath(
+                stage.WorkLocation, worker, worker.TilePoint, target.Path, out string failure))
+            throw new InvalidOperationException($"Feeding first step is unsafe: {failure}.");
+        stage.Controller = this.CreateController(
+            stage,
+            target.Path,
+            target.InteractionTile,
+            target.FacingDirection,
+            this.OnArrivedAtWork);
+        stage.Context.Lease.AttachController(stage.Controller);
+    }
+
+    private bool TryFeedTrough(ActiveAnimalCareStage stage, AnimalFeedingTargetPlan target)
+    {
+        if (stage.WorkLocation is not AnimalHouse house
+            || house.doesTileHaveProperty(
+                target.TargetTile.X,
+                target.TargetTile.Y,
+                "Trough",
+                "Back") is null
+            || house.objects.ContainsKey(target.TargetTile.ToVector2()))
+            return false;
+
+        StardewValley.Object? hay = GameLocation.GetHayFromAnySilo(house.GetRootLocation());
+        if (hay is null)
+            return false;
+        if (!house.objects.TryAdd(target.TargetTile.ToVector2(), hay))
+        {
+            int unstored = GameLocation.StoreHayInAnySilo(1, house.GetRootLocation());
+            if (unstored > 0)
+                throw new InvalidOperationException(
+                    "Consumed hay could not be restored after a failed trough placement.");
+            return false;
+        }
+        house.playSound("coin", target.TargetTile.ToVector2());
+        return true;
+    }
+
+    private static Point GetCurrentInteractionTile(ActiveAnimalCareStage stage)
+    {
+        return stage.CurrentFeedingTarget?.InteractionTile
+            ?? stage.CurrentTarget?.InteractionTile
+            ?? throw new InvalidOperationException("Animal-care travel has no current target.");
+    }
+
     private void OnReturned(Character character, GameLocation location)
     {
         if (this.ActiveStage is not { } stage
             || !ReferenceEquals(character, stage.Context.Lease.Worker)
-            || !ReferenceEquals(location, stage.Farm))
+            || !ReferenceEquals(location, stage.WorkLocation))
             return;
         stage.Context.Lease.Worker.Halt();
         stage.Phase = AnimalCarePhase.Returned;
@@ -310,7 +472,7 @@ internal sealed class AnimalCareContractExecutionController
             worker.controller = null;
         stage.Controller = null;
         worker.Position = FarmNavigationMap.GetAlignedCharacterPosition(destination);
-        callback(worker, stage.Farm);
+        callback(worker, stage.WorkLocation);
         return true;
     }
 
@@ -322,7 +484,7 @@ internal sealed class AnimalCareContractExecutionController
         PathFindController.endBehavior callback)
     {
         PathFindController controller = new(
-            new Stack<Point>(path.Reverse()), stage.Farm,
+            new Stack<Point>(path.Reverse()), stage.WorkLocation,
             stage.Context.Lease.Worker, destination)
         {
             finalFacingDirection = facing,
@@ -344,7 +506,7 @@ internal sealed class AnimalCareContractExecutionController
         this.LastCompletion = new NamedContractCompletionState(
             stage.Context.Id.ToString("N"), stage.Context.RequestId,
             stage.Context.Requester.UniqueMultiplayerID, stage.Context.Lease.Worker.Name,
-            NamedFarmTask.FarmWork, succeeded, reason, stage.PettedAnimals,
+            NamedFarmTask.FarmWork, succeeded, reason, stage.PettedAnimals + stage.FilledTroughs,
             0, 0, 0, 0, 0, 0, 0, 0,
             Array.Empty<NamedContractCargoState>(), Array.Empty<string>(),
             Array.Empty<NamedContractTransferState>(), Array.Empty<NamedContractTransferState>());
@@ -364,7 +526,172 @@ internal sealed class AnimalCareContractExecutionController
         return Game1.up;
     }
 
-    private enum AnimalCarePhase { Traveling, Acting, Returning, Returned }
+    private bool TryBeginNextHouse(ActiveAnimalCareStage stage)
+    {
+        AnimalHouseRoutePlan? route = this.HousePlanner.TryFindNext(
+            stage.Farm,
+            stage.Context.Lease.Worker,
+            stage.Context.Lease.Worker.TilePoint,
+            stage.VisitedBuildingIds);
+        if (route is null)
+            return false;
+
+        return this.BeginTravelToHouse(stage, route);
+    }
+
+    private bool BeginTravelToHouse(ActiveAnimalCareStage stage, AnimalHouseRoutePlan route)
+    {
+
+        stage.CurrentHouseRoute = route;
+        stage.Phase = AnimalCarePhase.TravelingToBuilding;
+        stage.PhaseTicks = 0;
+        if (stage.Context.Lease.Worker.TilePoint == route.ExteriorInteractionTile)
+        {
+            this.OnArrivedAtBuilding(stage.Context.Lease.Worker, stage.Farm);
+            return true;
+        }
+        try
+        {
+            if (!FarmNavigationMap.CanBeginPath(
+                    stage.Farm,
+                    stage.Context.Lease.Worker,
+                    stage.Context.Lease.Worker.TilePoint,
+                    route.ExteriorPath,
+                    out string failure))
+                throw new InvalidOperationException($"Animal-house first step is unsafe: {failure}.");
+            stage.Controller = this.CreateController(
+                stage,
+                route.ExteriorPath,
+                route.ExteriorInteractionTile,
+                Game1.up,
+                this.OnArrivedAtBuilding);
+            stage.Context.Lease.AttachController(stage.Controller);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            this.Monitor.Log(
+                $"Animal-house route {route.BuildingId:N} failed: {ex.Message}",
+                LogLevel.Warn);
+            stage.VisitedBuildingIds.Add(route.BuildingId);
+            stage.CurrentHouseRoute = null;
+            return this.TryBeginNextHouse(stage);
+        }
+    }
+
+    private void OnArrivedAtBuilding(Character character, GameLocation location)
+    {
+        if (this.ActiveStage is not { CurrentHouseRoute: { } route } stage
+            || !ReferenceEquals(character, stage.Context.Lease.Worker)
+            || !ReferenceEquals(location, stage.Farm)
+            || stage.Phase != AnimalCarePhase.TravelingToBuilding)
+            return;
+
+        stage.Farm.playSound("doorClose", route.ExteriorDoorTile.ToVector2());
+        Game1.warpCharacter(stage.Context.Lease.Worker, route.House, route.InteriorEntryTile.ToVector2());
+        stage.Context.Lease.Worker.Position =
+            FarmNavigationMap.GetAlignedCharacterPosition(route.InteriorEntryTile);
+        if (!ReferenceEquals(stage.Context.Lease.Worker.currentLocation, route.House)
+            || !route.House.characters.Contains(stage.Context.Lease.Worker))
+        {
+            this.Complete(stage, false, "contract.failure.dispatch");
+            return;
+        }
+        stage.WorkLocation = route.House;
+        stage.Context.Lease.Worker.Halt();
+        this.BeginNextOrReturn(stage);
+    }
+
+    private void BeginExitHouse(ActiveAnimalCareStage stage)
+    {
+        AnimalHouseRoutePlan route = stage.CurrentHouseRoute
+            ?? throw new InvalidOperationException("Animal-house exit has no active building.");
+        Stack<Point>? path = this.Planner.TryCreateReturnPath(
+            stage.WorkLocation,
+            stage.Context.Lease.Worker,
+            route.InteriorEntryTile);
+        if (path is null)
+        {
+            this.Complete(stage, false, "contract.failure.return-unreachable");
+            return;
+        }
+        stage.Phase = AnimalCarePhase.TravelingToHouseExit;
+        stage.PhaseTicks = 0;
+        if (stage.Context.Lease.Worker.TilePoint == route.InteriorEntryTile)
+        {
+            this.OnArrivedAtHouseExit(stage.Context.Lease.Worker, stage.WorkLocation);
+            return;
+        }
+        try
+        {
+            if (!FarmNavigationMap.CanBeginPath(
+                    stage.WorkLocation,
+                    stage.Context.Lease.Worker,
+                    stage.Context.Lease.Worker.TilePoint,
+                    path,
+                    out string failure))
+                throw new InvalidOperationException($"Animal-house exit step is unsafe: {failure}.");
+            stage.Controller = this.CreateController(
+                stage,
+                path,
+                route.InteriorEntryTile,
+                Game1.down,
+                this.OnArrivedAtHouseExit);
+            stage.Context.Lease.AttachController(stage.Controller);
+        }
+        catch (Exception ex)
+        {
+            this.Monitor.Log($"Animal-house exit failed: {ex.Message}", LogLevel.Warn);
+            this.Complete(stage, false, "contract.failure.return-unreachable");
+        }
+    }
+
+    private void OnArrivedAtHouseExit(Character character, GameLocation location)
+    {
+        if (this.ActiveStage is not { CurrentHouseRoute: { } route } stage
+            || !ReferenceEquals(character, stage.Context.Lease.Worker)
+            || !ReferenceEquals(location, route.House)
+            || stage.Phase != AnimalCarePhase.TravelingToHouseExit)
+            return;
+
+        route.House.playSound("doorClose", route.InteriorEntryTile.ToVector2());
+        Game1.warpCharacter(
+            stage.Context.Lease.Worker,
+            stage.Farm,
+            route.ExteriorInteractionTile.ToVector2());
+        stage.Context.Lease.Worker.Position =
+            FarmNavigationMap.GetAlignedCharacterPosition(route.ExteriorInteractionTile);
+        if (!ReferenceEquals(stage.Context.Lease.Worker.currentLocation, stage.Farm)
+            || !stage.Farm.characters.Contains(stage.Context.Lease.Worker))
+        {
+            this.Complete(stage, false, "contract.failure.dispatch");
+            return;
+        }
+        stage.WorkLocation = stage.Farm;
+        stage.VisitedBuildingIds.Add(route.BuildingId);
+        stage.CurrentHouseRoute = null;
+        stage.Context.Lease.Worker.Halt();
+        this.BeginNextOrReturn(stage);
+    }
+
+    private bool HasControllerConflict(ActiveAnimalCareStage stage)
+    {
+        if (stage.Context.Lease.Worker.controller is null
+            || ReferenceEquals(stage.Context.Lease.Worker.controller, stage.Controller))
+            return false;
+        this.Complete(stage, false, "contract.failure.controller-conflict");
+        return true;
+    }
+
+    private enum AnimalCarePhase
+    {
+        Traveling,
+        Acting,
+        TravelingToBuilding,
+        TravelingToHouseExit,
+        Returning,
+        Returned
+    }
 
     private sealed class ActiveAnimalCareStage
     {
@@ -374,16 +701,23 @@ internal sealed class AnimalCareContractExecutionController
             this.Farm = farm;
             this.Plan = plan;
             this.CurrentTarget = plan.FirstTarget;
+            this.WorkLocation = farm;
         }
         public FarmWorkShiftContext Context { get; }
         public Farm Farm { get; }
         public AnimalPettingWorkPlan Plan { get; }
-        public AnimalPettingTargetPlan CurrentTarget { get; set; }
+        public AnimalPettingTargetPlan? CurrentTarget { get; set; }
+        public AnimalFeedingTargetPlan? CurrentFeedingTarget { get; set; }
+        public GameLocation WorkLocation { get; set; }
+        public AnimalHouseRoutePlan? CurrentHouseRoute { get; set; }
+        public HashSet<Guid> VisitedBuildingIds { get; } = new();
+        public HashSet<Point> AttemptedTroughTiles { get; } = new();
         public HashSet<long> AttemptedAnimalIds { get; } = new();
         public AnimalCarePhase Phase { get; set; }
         public PathFindController? Controller { get; set; }
         public int PhaseTicks { get; set; }
         public bool ActionApplied { get; set; }
         public int PettedAnimals { get; set; }
+        public int FilledTroughs { get; set; }
     }
 }

--- a/src/AnimalFeedingTargetPlanner.cs
+++ b/src/AnimalFeedingTargetPlanner.cs
@@ -1,0 +1,94 @@
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Locations;
+
+namespace EvilFarmOwner;
+
+internal sealed record AnimalFeedingTargetPlan(
+    Point TargetTile,
+    Point InteractionTile,
+    int FacingDirection,
+    Stack<Point> Path);
+
+internal sealed class AnimalFeedingTargetPlanner
+{
+    private static readonly Point[] InteractionOffsets =
+    {
+        new(0, 1), new(-1, 0), new(1, 0), new(0, -1)
+    };
+    private readonly IMonitor Monitor;
+
+    public AnimalFeedingTargetPlanner(IMonitor monitor) => this.Monitor = monitor;
+
+    public AnimalFeedingTargetPlan? TryFindNext(
+        AnimalHouse house,
+        NPC worker,
+        Point startTile,
+        IReadOnlySet<Point> attemptedTiles)
+    {
+        if (!FarmNavigationMap.TryBuild(house, worker, startTile, this.Monitor, out GridRouteMap? routes)
+            || routes is null)
+            return null;
+        List<(Point Target, Point Interaction, int Distance)> options = new();
+        int width = house.Map.Layers[0].LayerWidth;
+        int height = house.Map.Layers[0].LayerHeight;
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                Point target = new(x, y);
+                if (attemptedTiles.Contains(target)
+                    || house.objects.ContainsKey(target.ToVector2())
+                    || house.doesTileHaveProperty(x, y, "Trough", "Back") is null)
+                    continue;
+                foreach (Point offset in InteractionOffsets)
+                {
+                    Point interaction = new(x + offset.X, y + offset.Y);
+                    if (routes.TryGetDistance(new GridPoint(interaction.X, interaction.Y), out int distance))
+                        options.Add((target, interaction, distance));
+                }
+            }
+        }
+        if (options.Count == 0)
+            return null;
+        (Point Target, Point Interaction, int Distance) best = options
+            .OrderBy(option => option.Distance)
+            .ThenBy(option => option.Target.Y)
+            .ThenBy(option => option.Target.X)
+            .ThenBy(option => option.Interaction.Y)
+            .ThenBy(option => option.Interaction.X)
+            .First();
+        if (!routes.TryGetPath(new GridPoint(best.Interaction.X, best.Interaction.Y), out IReadOnlyList<GridPoint> path))
+            return null;
+        return new AnimalFeedingTargetPlan(
+            best.Target,
+            best.Interaction,
+            GetFacingDirection(best.Interaction, best.Target),
+            FarmNavigationMap.ToPath(path));
+    }
+
+    public static bool HasEmptyTrough(AnimalHouse house)
+    {
+        int width = house.Map.Layers[0].LayerWidth;
+        int height = house.Map.Layers[0].LayerHeight;
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                if (house.doesTileHaveProperty(x, y, "Trough", "Back") is not null
+                    && !house.objects.ContainsKey(new Vector2(x, y)))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static int GetFacingDirection(Point interaction, Point target)
+    {
+        if (target.X > interaction.X) return Game1.right;
+        if (target.X < interaction.X) return Game1.left;
+        if (target.Y > interaction.Y) return Game1.down;
+        return Game1.up;
+    }
+}

--- a/src/AnimalHouseRoutePlanner.cs
+++ b/src/AnimalHouseRoutePlanner.cs
@@ -1,0 +1,135 @@
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Buildings;
+using StardewValley.Locations;
+
+namespace EvilFarmOwner;
+
+internal sealed record AnimalHouseRoutePlan(
+    Guid BuildingId,
+    Building Building,
+    AnimalHouse House,
+    Point ExteriorDoorTile,
+    Point ExteriorInteractionTile,
+    Point InteriorEntryTile,
+    Stack<Point> ExteriorPath,
+    int Distance);
+
+internal sealed record AnimalHouseWorkPlan(
+    Point ArrivalTile,
+    FarmBoundarySide ArrivalSide,
+    AnimalHouseRoutePlan FirstHouse);
+
+internal sealed class AnimalHouseRoutePlanner
+{
+    private readonly IMonitor Monitor;
+
+    public AnimalHouseRoutePlanner(IMonitor monitor)
+    {
+        this.Monitor = monitor;
+    }
+
+    public AnimalHouseWorkPlan? TryCreate(Farm farm, NPC worker)
+    {
+        int width = farm.Map.Layers[0].LayerWidth;
+        int height = farm.Map.Layers[0].LayerHeight;
+        foreach (GridPoint candidate in FarmEntranceSelection.OrderBoundaryArrivalCandidates(
+                     width,
+                     height,
+                     farm.warps.Select(warp => new GridPoint(warp.X, warp.Y))))
+        {
+            Vector2 tile = new(candidate.X, candidate.Y);
+            if (farm.warps.Any(warp => warp.X == candidate.X && warp.Y == candidate.Y)
+                || farm.doors.ContainsKey(new Point(candidate.X, candidate.Y))
+                || !farm.CanSpawnCharacterHere(tile))
+                continue;
+            Point arrival = new(candidate.X, candidate.Y);
+            AnimalHouseRoutePlan? house = this.TryFindNext(
+                farm,
+                worker,
+                arrival,
+                new HashSet<Guid>());
+            if (house is not null
+                && FarmNavigationMap.CanBeginPath(
+                    farm, worker, arrival, house.ExteriorPath, out _))
+            {
+                return new AnimalHouseWorkPlan(
+                    arrival,
+                    FarmEntranceSelection.GetNearestBoundarySide(width, height, candidate),
+                    house);
+            }
+        }
+        return null;
+    }
+
+    public AnimalHouseRoutePlan? TryFindNext(
+        Farm farm,
+        NPC worker,
+        Point startTile,
+        IReadOnlySet<Guid> visitedBuildingIds)
+    {
+        if (!FarmNavigationMap.TryBuild(farm, worker, startTile, this.Monitor, out GridRouteMap? routes)
+            || routes is null)
+            return null;
+
+        List<AnimalHouseRoutePlan> candidates = new();
+        foreach (Building building in farm.buildings)
+        {
+            Guid buildingId = building.id.Value;
+            if (visitedBuildingIds.Contains(buildingId)
+                || building.daysOfConstructionLeft.Value > 0
+                || building.daysUntilUpgrade.Value > 0
+                || building.GetIndoors() is not AnimalHouse house
+                || house.warps.Count == 0
+                || !HasEligibleWork(house))
+                continue;
+
+            Point door = building.getPointForHumanDoor();
+            Point interaction = new(door.X, door.Y + 1);
+            if (!routes.TryGetDistance(
+                    new GridPoint(interaction.X, interaction.Y),
+                    out int distance)
+                || !routes.TryGetPath(
+                    new GridPoint(interaction.X, interaction.Y),
+                    out IReadOnlyList<GridPoint> path))
+                continue;
+
+            Warp warp = house.warps[0];
+            Point interiorEntry = new(warp.X, warp.Y - 1);
+            if (interiorEntry.X < 0
+                || interiorEntry.Y < 0
+                || interiorEntry.X >= house.Map.Layers[0].LayerWidth
+                || interiorEntry.Y >= house.Map.Layers[0].LayerHeight)
+                continue;
+
+            candidates.Add(new AnimalHouseRoutePlan(
+                buildingId,
+                building,
+                house,
+                door,
+                interaction,
+                interiorEntry,
+                FarmNavigationMap.ToPath(path),
+                distance));
+        }
+
+        return candidates
+            .OrderBy(candidate => candidate.Distance)
+            .ThenBy(candidate => candidate.ExteriorDoorTile.Y)
+            .ThenBy(candidate => candidate.ExteriorDoorTile.X)
+            .ThenBy(candidate => candidate.BuildingId)
+            .FirstOrDefault();
+    }
+
+    public static bool HasEligibleWork(AnimalHouse house)
+    {
+        return AnimalFeedingTargetPlanner.HasEmptyTrough(house)
+            || house.animals.Values.Any(animal =>
+            ReferenceEquals(animal.currentLocation, house)
+            && AnimalPettingPolicy.GetSkipReason(
+                Context.IsMainPlayer,
+                animal.wasPet.Value,
+                Game1.timeOfDay >= 1900) == AnimalCareSkipReason.None);
+    }
+}

--- a/src/AnimalPettingTargetPlanner.cs
+++ b/src/AnimalPettingTargetPlanner.cs
@@ -15,7 +15,7 @@ internal sealed record AnimalPettingTargetPlan(
 internal sealed record AnimalPettingWorkPlan(
     Point ArrivalTile,
     FarmBoundarySide ArrivalSide,
-    AnimalPettingTargetPlan FirstTarget);
+    AnimalPettingTargetPlan? FirstTarget);
 
 internal sealed record AnimalPettingRouteOption(
     long AnimalId,
@@ -68,7 +68,7 @@ internal sealed class AnimalPettingTargetPlanner
     }
 
     public AnimalPettingTargetPlan? TryFindNext(
-        Farm farm,
+        GameLocation farm,
         NPC worker,
         Point startTile,
         IReadOnlySet<long> attemptedAnimalIds)
@@ -136,7 +136,7 @@ internal sealed class AnimalPettingTargetPlanner
             .ToArray();
     }
 
-    public Stack<Point>? TryCreateReturnPath(Farm farm, NPC worker, Point arrivalTile)
+    public Stack<Point>? TryCreateReturnPath(GameLocation farm, NPC worker, Point arrivalTile)
     {
         if (!FarmNavigationMap.TryBuild(farm, worker, worker.TilePoint, this.Monitor, out GridRouteMap? routes)
             || routes is null

--- a/src/FarmNavigationMap.cs
+++ b/src/FarmNavigationMap.cs
@@ -104,7 +104,7 @@ internal static class FarmNavigationMap
     private const int VanillaNpcWalkingPixelsPerTick = 2;
 
     public static bool TryBuild(
-        Farm farm,
+        GameLocation farm,
         NPC worker,
         Point startTile,
         IMonitor monitor,
@@ -163,7 +163,7 @@ internal static class FarmNavigationMap
     }
 
     public static bool CanBeginPath(
-        Farm farm,
+        GameLocation farm,
         NPC worker,
         Point startTile,
         Stack<Point> path,
@@ -265,7 +265,7 @@ internal static class FarmNavigationMap
         return true;
     }
 
-    private static bool IsPassable(Farm farm, NPC worker, GridPoint tile)
+    private static bool IsPassable(GameLocation farm, NPC worker, GridPoint tile)
     {
         if (farm.warps.Any(warp => warp.X == tile.X && warp.Y == tile.Y)
             || farm.doors.ContainsKey(new Point(tile.X, tile.Y)))


### PR DESCRIPTION
Refs #86

## Summary
- route workers through each barn/coop human door and original interior warp, then return through the same building
- support indoor animal petting even when no outdoor animal target exists
- fill empty valid trough tiles one at a time using real silo hay
- restore consumed hay if a trough placement cannot commit
- skip unreachable buildings without destructive pathing and fail closed if an entered interior cannot be exited safely

## Verification
- Release build: 0 warnings, 0 errors
- deterministic logic suite: 93 passed
- bilingual JSON validation passed

No in-game acceptance was run.