### PR TITLE
feat(animals): plan safe product collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added deterministic, non-mutating discovery for loose and tool-harvested animal products, excluding auto-grabber-owned rooms and player-placeable lookalikes until lossless delivery is ready.
 - Added safe barn/coop human-door transitions, indoor animal petting, and finite-silo-hay trough feeding to complete shifts.
 - Added host-owned, non-destructive outdoor animal petting to complete shifts, with stable animal identities, daily idempotency, worker movement, and final reconciliation.
 - Reserved deterministic multi-worker scheduling with stable target identities, exclusive host-owned claims, efficiency-aware partitioning, and checked per-worker wage aggregation; concurrent dispatch remains disabled pending runtime safety coverage.

--- a/docs/ANIMAL_OPERATION_MATRIX.md
+++ b/docs/ANIMAL_OPERATION_MATRIX.md
@@ -2,6 +2,8 @@
 
 Outdoor and barn/coop petting now participate in complete shifts with stable animal IDs, host-owned mutation, non-destructive routes, and final reconciliation. Workers use each building's human door and original interior warp, then return through the same entrance. Empty troughs are filled one at a time from real silo hay with rollback on placement failure. Product rows stay disabled until each has a commit check and lossless recovery path.
 
+Product discovery now fails closed around auto-grabbers and recognizes only vanilla-owned sources: tool-ready adult animals, or non-placeable loose objects whose IDs appear in resident drop-over-night animal data. This discovery layer does not remove or deliver products yet.
+
 | Operation | Eligibility | Required state transition | Product/storage rule |
 | --- | --- | --- | --- |
 | Pet | Host, awake animal, `wasPet == false` | Use the normal manual-pet effects once, including the reduced gain after auto-petting, mood/friendship caps, profession effects, farming XP, texture/emote state, and `wasPet` | No item output. A repeated or replayed target is skipped. |

--- a/src/AnimalCarePolicy.cs
+++ b/src/AnimalCarePolicy.cs
@@ -101,3 +101,19 @@ internal static class AnimalProducePolicy
         return AnimalCareSkipReason.None;
     }
 }
+
+internal static class AnimalProductSourcePolicy
+{
+    public static bool IsEligibleLooseProduct(
+        string qualifiedItemId,
+        bool isBigCraftable,
+        bool canBeSetDown,
+        IReadOnlySet<string> allowedProductIds)
+    {
+        return !string.IsNullOrWhiteSpace(qualifiedItemId)
+            && !isBigCraftable
+            && !canBeSetDown
+            && qualifiedItemId != "(O)178"
+            && allowedProductIds.Contains(qualifiedItemId);
+    }
+}

--- a/src/AnimalProductTargetPlanner.cs
+++ b/src/AnimalProductTargetPlanner.cs
@@ -1,0 +1,180 @@
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.GameData.FarmAnimals;
+using StardewValley.Locations;
+
+namespace EvilFarmOwner;
+
+internal enum AnimalProductTargetKind
+{
+    LooseOvernightProduct,
+    ToolHarvestAnimal
+}
+
+internal sealed record AnimalProductTargetPlan(
+    string StableKey,
+    AnimalProductTargetKind Kind,
+    long? AnimalId,
+    Point TargetTile,
+    Point InteractionTile,
+    int FacingDirection,
+    string QualifiedItemId,
+    int Stack,
+    int Quality,
+    string? RequiredTool,
+    Stack<Point> Path);
+
+internal sealed record AnimalProductRouteOption(
+    string StableKey,
+    GridPoint Target,
+    GridPoint Interaction,
+    int Distance);
+
+internal sealed class AnimalProductTargetPlanner
+{
+    private static readonly Point[] InteractionOffsets =
+    {
+        new(0, 1), new(-1, 0), new(1, 0), new(0, -1)
+    };
+    private readonly IMonitor Monitor;
+
+    public AnimalProductTargetPlanner(IMonitor monitor) => this.Monitor = monitor;
+
+    public AnimalProductTargetPlan? TryFindNext(
+        AnimalHouse house,
+        NPC worker,
+        Point startTile,
+        IReadOnlySet<string> attemptedTargets)
+    {
+        if (HasAutoGrabber(house)
+            || !FarmNavigationMap.TryBuild(
+                house, worker, startTile, this.Monitor, out GridRouteMap? routes)
+            || routes is null)
+            return null;
+
+        Dictionary<string, AnimalProductTargetPlan> targets = new(StringComparer.Ordinal);
+        List<AnimalProductRouteOption> options = new();
+        HashSet<string> looseIds = GetLooseProductIds(house);
+        foreach (KeyValuePair<Vector2, StardewValley.Object> pair in house.objects.Pairs)
+        {
+            StardewValley.Object item = pair.Value;
+            Point tile = new((int)pair.Key.X, (int)pair.Key.Y);
+            string key = $"loose:{house.NameOrUniqueName}:{tile.X}:{tile.Y}:{item.QualifiedItemId}";
+            if (attemptedTargets.Contains(key)
+                || !AnimalProductSourcePolicy.IsEligibleLooseProduct(
+                    item.QualifiedItemId,
+                    item.bigCraftable.Value,
+                    item.CanBeSetDown,
+                    looseIds))
+                continue;
+            AddOptions(routes, options, key, tile);
+            targets[key] = new AnimalProductTargetPlan(
+                key, AnimalProductTargetKind.LooseOvernightProduct, null,
+                tile, tile, Game1.down, item.QualifiedItemId,
+                item.Stack, item.Quality, null, new Stack<Point>());
+        }
+
+        foreach (FarmAnimal animal in house.animals.Values)
+        {
+            FarmAnimalData? data = animal.GetAnimalData();
+            string key = $"tool:{house.NameOrUniqueName}:{animal.myID.Value}";
+            AnimalCareSkipReason result = AnimalProducePolicy.TryCreateToolHarvestPlan(
+                Context.IsMainPlayer,
+                animal.isAdult(),
+                animal.currentProduce.Value,
+                data?.HarvestType == FarmAnimalHarvestType.HarvestWithTool,
+                data?.HarvestTool,
+                animal.hasEatenAnimalCracker.Value,
+                animal.produceQuality.Value,
+                autoGrabberOwnsProduce: false,
+                out AnimalProducePlan? product);
+            if (attemptedTargets.Contains(key)
+                || result != AnimalCareSkipReason.None
+                || product is null
+                || !ReferenceEquals(animal.currentLocation, house))
+                continue;
+            Point tile = animal.TilePoint;
+            AddOptions(routes, options, key, tile);
+            targets[key] = new AnimalProductTargetPlan(
+                key, AnimalProductTargetKind.ToolHarvestAnimal, animal.myID.Value,
+                tile, tile, Game1.down, product.QualifiedItemId,
+                product.Stack, product.Quality, product.RequiredTool, new Stack<Point>());
+        }
+
+        AnimalProductRouteOption? best = OrderOptions(options).FirstOrDefault();
+        if (best is null
+            || !targets.TryGetValue(best.StableKey, out AnimalProductTargetPlan? target)
+            || !routes.TryGetPath(best.Interaction, out IReadOnlyList<GridPoint> path))
+            return null;
+        Point interaction = new(best.Interaction.X, best.Interaction.Y);
+        return target with
+        {
+            InteractionTile = interaction,
+            FacingDirection = GetFacingDirection(interaction, target.TargetTile),
+            Path = FarmNavigationMap.ToPath(path)
+        };
+    }
+
+    public static IReadOnlyList<AnimalProductRouteOption> OrderOptions(
+        IEnumerable<AnimalProductRouteOption> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return options
+            .OrderBy(option => option.Distance)
+            .ThenBy(option => option.Target.Y)
+            .ThenBy(option => option.Target.X)
+            .ThenBy(option => option.Interaction.Y)
+            .ThenBy(option => option.Interaction.X)
+            .ThenBy(option => option.StableKey, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public static bool HasAutoGrabber(AnimalHouse house)
+    {
+        return house.objects.Values.Any(item => item.QualifiedItemId == "(BC)165");
+    }
+
+    private static HashSet<string> GetLooseProductIds(AnimalHouse house)
+    {
+        HashSet<string> ids = new(StringComparer.Ordinal);
+        foreach (FarmAnimal animal in house.animals.Values)
+        {
+            FarmAnimalData? data = animal.GetAnimalData();
+            if (data?.HarvestType != FarmAnimalHarvestType.DropOvernight)
+                continue;
+            foreach (FarmAnimalProduce produce in data.ProduceItemIds.Concat(data.DeluxeProduceItemIds))
+                ids.Add(ItemRegistry.QualifyItemId(produce.ItemId) ?? $"(O){produce.ItemId}");
+        }
+        return ids;
+    }
+
+    private static void AddOptions(
+        GridRouteMap routes,
+        ICollection<AnimalProductRouteOption> options,
+        string stableKey,
+        Point target)
+    {
+        foreach (Point offset in InteractionOffsets)
+        {
+            Point interaction = new(target.X + offset.X, target.Y + offset.Y);
+            GridPoint grid = new(interaction.X, interaction.Y);
+            if (routes.TryGetDistance(grid, out int distance))
+            {
+                options.Add(new AnimalProductRouteOption(
+                    stableKey,
+                    new GridPoint(target.X, target.Y),
+                    grid,
+                    distance));
+            }
+        }
+    }
+
+    private static int GetFacingDirection(Point interaction, Point target)
+    {
+        if (target.X > interaction.X) return Game1.right;
+        if (target.X < interaction.X) return Game1.left;
+        if (target.Y > interaction.Y) return Game1.down;
+        return Game1.up;
+    }
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -21,6 +21,8 @@ List<(string Name, Action Test)> tests = new()
     ("animal petting route ordering", TestAnimalPettingRouteOrdering),
     ("animal finite hay conservation", TestAnimalFiniteHayConservation),
     ("animal tool produce readiness", TestAnimalToolProduceReadiness),
+    ("animal loose product ownership", TestAnimalLooseProductOwnership),
+    ("animal product route ordering", TestAnimalProductRouteOrdering),
     ("recurring contract state validation", TestRecurringContractStateValidation),
     ("recurring contract candidate pool", TestRecurringContractCandidatePool),
     ("recurring contract ranking", TestRecurringContractRanking),
@@ -427,6 +429,36 @@ static void TestAnimalToolProduceReadiness()
         true, true, "184", false, "Milk Pail", false, 0, false, out _));
     Equal(AnimalCareSkipReason.AutoGrabberOwned, AnimalProducePolicy.TryCreateToolHarvestPlan(
         true, true, "184", true, "Milk Pail", false, 0, true, out _));
+}
+
+static void TestAnimalLooseProductOwnership()
+{
+    IReadOnlySet<string> allowed = new HashSet<string> { "(O)176", "(O)174" };
+    Equal(true, AnimalProductSourcePolicy.IsEligibleLooseProduct(
+        "(O)176", false, false, allowed));
+    Equal(false, AnimalProductSourcePolicy.IsEligibleLooseProduct(
+        "(O)176", false, true, allowed));
+    Equal(false, AnimalProductSourcePolicy.IsEligibleLooseProduct(
+        "(O)178", false, false, allowed));
+    Equal(false, AnimalProductSourcePolicy.IsEligibleLooseProduct(
+        "(BC)165", true, false, allowed));
+    Equal(false, AnimalProductSourcePolicy.IsEligibleLooseProduct(
+        "(O)390", false, false, allowed));
+}
+
+static void TestAnimalProductRouteOrdering()
+{
+    AnimalProductRouteOption[] options =
+    {
+        new("tool:b", new(5, 5), new(5, 6), 8),
+        new("tool:a", new(5, 5), new(5, 6), 8),
+        new("loose:c", new(8, 8), new(8, 9), 2)
+    };
+    IReadOnlyList<AnimalProductRouteOption> ordered =
+        AnimalProductTargetPlanner.OrderOptions(options.Reverse());
+    Equal("loose:c", ordered[0].StableKey);
+    Equal("tool:a", ordered[1].StableKey);
+    Equal("tool:b", ordered[2].StableKey);
 }
 
 static void TestRecurringContractStateValidation()


### PR DESCRIPTION
Refs #86

## Summary
- discover tool-ready milk/wool animals with exact vanilla item, cracker stack, quality, and required-tool semantics
- discover loose overnight products only when the object is non-placeable and allowlisted by resident animal data
- fail closed for any room containing an auto-grabber
- assign stable source identities and deterministic interaction routes without mutating the world
- keep collection disabled until classified-chest/requester delivery and rollback are connected

## Verification
- Release build: 0 warnings, 0 errors
- deterministic logic suite: 95 passed

No in-game acceptance was run.