### PR TITLE
feat(animals): collect livestock products safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added deterministic, non-mutating discovery for loose and tool-harvested animal products, excluding auto-grabber-owned rooms and player-placeable lookalikes until lossless delivery is ready.
+- Added lossless collection of eggs and other resident-animal loose products plus tool-ready milk and wool, with exact vanilla produce state, locked deterministic destinations, rollback on failed commits, and auto-grabber exclusion.
 - Added safe barn/coop human-door transitions, indoor animal petting, and finite-silo-hay trough feeding to complete shifts.
 - Added host-owned, non-destructive outdoor animal petting to complete shifts, with stable animal identities, daily idempotency, worker movement, and final reconciliation.
 - Reserved deterministic multi-worker scheduling with stable target identities, exclusive host-owned claims, efficiency-aware partitioning, and checked per-worker wage aggregation; concurrent dispatch remains disabled pending runtime safety coverage.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 </p>
 
 <p align="center">
-  花钱雇佣镇民，让他们真正走进农场，帮你浇水、收获和整理箱子。<br>
-  Hire townspeople to walk onto your farm and help with watering, harvesting, and chest sorting.
+  花钱雇佣镇民，让他们真正走进农场，帮你浇水、收获、照顾动物和整理箱子。<br>
+  Hire townspeople to walk onto your farm and help with watering, harvesting, animal care, and chest sorting.
 </p>
 
 <p align="center">
@@ -36,6 +36,7 @@
 
 - 浇灌所有能够安全到达的缺水作物；
 - 收获所有能够安全到达的成熟作物，以及树上已经就绪的普通或重型树液采集器产物；
+- 进入畜棚和鸡舍，抚摸动物、用自有干草补满食槽，并收集鸡蛋、牛奶和羊毛；
 - 按箱子里已有的物品整理普通箱子；
 - 设置每天自动尝试执行的完整农活班次。
 
@@ -66,7 +67,7 @@
 2. 按 `K` 打开工人名单。
 3. 选择一位绿色显示、当前可以雇佣的 NPC。
 4. 查看工资、收获物目的地和完整工作范围，确认雇佣。
-5. 工人会依次收获、浇水、整理箱子；当前没有工作的阶段会自动跳过。
+5. 工人会依次收获、浇水、照顾动物、整理箱子；当前没有工作的阶段会自动跳过。
 6. 等待工人完成整个班次并返回。
 
 同一时间只能执行一份合同。合同最迟需要在下午 4:00 前开始，并会在晚上 10:00 前安全结束。
@@ -131,7 +132,7 @@ Mods/EvilFarmOwner/config.json
 
 ### 当前限制
 
-- 暂不支持清理杂物、播种、施肥、照顾动物、补充普通生产机器或自动出售；收获合同仅额外支持树上的普通与重型树液采集器。
+- 暂不支持清理杂物、播种、施肥、补充普通生产机器或自动出售；动物自动采集器的内部箱子也不会被本 Mod 接管。
 - 暂不支持特殊箱子和其他 Mod 添加的箱子。
 - 自动合同与手动雇佣执行同一套完整班次，包括当前可执行的箱子整理。
 - 个别农场布局可能没有安全路线；这种情况下合同会拒绝开始或提前停止。
@@ -151,6 +152,7 @@ Each hire automatically works through these stages in order:
 
 - water every safely reachable dry crop;
 - harvest every safely reachable mature crop and every ready normal or heavy tree tapper;
+- enter barns and coops to pet animals, fill troughs from owned silo hay, and collect eggs, milk, and wool;
 - organize ordinary farm chests based on their existing contents;
 - set up a daily automatic complete farm-work shift.
 
@@ -176,7 +178,7 @@ Requires Stardew Valley 1.6+ and SMAPI 4.0+.
 
 ### Play
 
-Stand on the main farm, press `K`, choose a green available worker, review the wage and harvest destination, then confirm. The worker harvests, waters, and sorts ordinary farm chests in that order; stages with no ready work are skipped automatically.
+Stand on the main farm, press `K`, choose a green available worker, review the wage and harvest destination, then confirm. The worker harvests, waters, cares for livestock, and sorts ordinary farm chests in that order; stages with no ready work are skipped automatically.
 
 Only one named contract can run at a time. Contracts must start by 4:00 PM and stop safely before 10:00 PM.
 
@@ -210,7 +212,7 @@ Most players only need the `K` key. The extra commands help inspect recent work 
 
 ### Current limitations
 
-- No debris clearing, planting, fertilizing, animal care, ordinary machine collection/refilling, or automatic shipping. Harvest contracts additionally support only normal and heavy tappers attached to trees.
+- No debris clearing, planting, fertilizing, ordinary machine collection/refilling, or automatic shipping. Auto-grabber contents are deliberately excluded from livestock collection.
 - No special or modded chest support.
 - Automatic contracts use the same harvest, watering, and chest-sorting sequence as manual hiring.
 - Some farm layouts may not provide a safe route; the contract will refuse or stop instead of breaking objects.

--- a/docs/ANIMAL_OPERATION_MATRIX.md
+++ b/docs/ANIMAL_OPERATION_MATRIX.md
@@ -1,15 +1,15 @@
 # Vanilla animal-operation matrix
 
-Outdoor and barn/coop petting now participate in complete shifts with stable animal IDs, host-owned mutation, non-destructive routes, and final reconciliation. Workers use each building's human door and original interior warp, then return through the same entrance. Empty troughs are filled one at a time from real silo hay with rollback on placement failure. Product rows stay disabled until each has a commit check and lossless recovery path.
+Outdoor and barn/coop petting participate in complete shifts with stable animal IDs, host-owned mutation, non-destructive routes, and final reconciliation. Workers use each building's human door and original interior warp, then return through the same entrance. Empty troughs are filled one at a time from real silo hay with rollback on placement failure.
 
-Product discovery now fails closed around auto-grabbers and recognizes only vanilla-owned sources: tool-ready adult animals, or non-placeable loose objects whose IDs appear in resident drop-over-night animal data. This discovery layer does not remove or deliver products yet.
+Product collection fails closed around auto-grabbers and recognizes only vanilla-owned sources: tool-ready adult animals, or non-placeable loose objects whose IDs appear in resident drop-over-night animal data. The exact source remains untouched until the contract-selected requester inventory or deterministic classified chest is revalidated. Chest writes run under that chest's mutex; destination insertion and source mutation share a rollback boundary. A changed source is skipped, while a changed/full destination stops the shift with the source intact.
 
 | Operation | Eligibility | Required state transition | Product/storage rule |
 | --- | --- | --- | --- |
 | Pet | Host, awake animal, `wasPet == false` | Use the normal manual-pet effects once, including the reduced gain after auto-petting, mood/friendship caps, profession effects, farming XP, texture/emote state, and `wasPet` | No item output. A repeated or replayed target is skipped. |
 | Fill trough | Empty map tile marked `Trough`; owned silo hay is available | Consume exactly one owned hay before adding exactly one hay object; stop when either capacity or hay reaches zero | Never create hay, take hay from player inventory implicitly, replace an occupied tile, or exceed valid trough capacity. |
-| Loose overnight product | Object is in an animal-house location and its qualified ID is allowlisted by a resident animal's drop-over-night produce data | Remove one stable location/tile/object target only after cargo recovery is established | Route the exact item, stack, and quality through the shift destination. Never collect placed machines, furniture, quest items, or auto-grabber contents. |
-| Milk or shear | Host; adult; non-null `currentProduce`; harvest type is `HarvestWithTool`; animal data names a tool; auto-grabber does not own the product | Create the configured product with stored quality and cracker stack, then preserve vanilla stats, clear `currentProduce`, add 5 friendship, reload texture, and grant 5 farming XP | The tool name is semantic input; the player does not need to own or equip a pail/shears. Clear produce only after the exact output has entered the recovery pipeline. |
+| Loose overnight product | Object is in an animal-house location and its qualified ID is allowlisted by a resident animal's drop-over-night produce data | Remove one stable location/tile/object target only after the complete destination write succeeds | Preserve the exact item, stack, quality, and metadata. Never collect placed machines, furniture, quest items, or auto-grabber contents. |
+| Milk or shear | Host; adult; non-null `currentProduce`; harvest type is `HarvestWithTool`; animal data names a tool; auto-grabber does not own the product | Create the configured product with stored quality and cracker stack, then call vanilla produce-stat handling, clear `currentProduce`, add 5 friendship, reload texture, and grant 5 farming XP | The tool name is semantic input; the player does not need to own or equip a pail/shears. Produce is cleared only after the complete destination write succeeds. |
 | Dig-up product | Produced as a loose outdoor object by the animal | No direct animal mutation during collection | Later handled by a narrowly allowlisted loose-product collector; ordinary forage and player-placed objects remain excluded. |
 | Auto-grabber | Machine owns its internal chest and collection timing | No mutation by the animal-care stage | Excluded. Sorting auto-grabber contents requires a separate locked-container design. |
 
@@ -20,3 +20,11 @@ Product discovery now fails closed around auto-grabbers and recognizes only vani
 - Entering barns/coops requires a real building transition and an independently planned return path. Ordinary doors may be opened when allowed, but no farm object is destroyed.
 - Sleeping, pregnancy/birth, festivals/events, unavailable interiors, and location changes cause an explicit skip or replan, never a blind mutation.
 - Final reconciliation may discover an unclaimed target once more. A committed animal/day or product identity is never repeated.
+
+## Destination and rollback boundary
+
+- The selected shift destination never changes implicitly. Requester delivery requires that player to remain online, on the main farm, and able to accept the complete stack.
+- Classified storage uses the same exact-stack, same-item, same-category, and empty-chest ranking as crop harvests. One chest must accept the complete stack.
+- The chest is selected deterministically and locked before commit. Capacity, classification, chest identity, source identity, stack, and quality are revalidated under the lock.
+- A failed insertion restores the destination snapshot. A source that changed before commit is left alone and reported as skipped. No animal product is shipped, dropped invisibly, or split across destinations.
+- Auto-grabber rooms remain excluded. Their internal chests require a separate locked-container design.

--- a/src/AnimalCareContractExecutionController.cs
+++ b/src/AnimalCareContractExecutionController.cs
@@ -12,10 +12,13 @@ internal sealed class AnimalCareContractExecutionController
     private const int ActionStartTicks = 8;
     private const int ActionDurationTicks = 32;
     private const int MaximumTravelTicks = 3600;
+    private const int MaximumProductLockWaitTicks = 300;
     private readonly IMonitor Monitor;
     private readonly AnimalPettingTargetPlanner Planner;
     private readonly AnimalHouseRoutePlanner HousePlanner;
     private readonly AnimalFeedingTargetPlanner FeedingPlanner;
+    private readonly AnimalProductTargetPlanner ProductPlanner;
+    private readonly AnimalProductTransferService ProductTransfer = new();
     private ActiveAnimalCareStage? ActiveStage;
     private NamedContractCompletionState? LastCompletion;
 
@@ -25,6 +28,7 @@ internal sealed class AnimalCareContractExecutionController
         this.Planner = new AnimalPettingTargetPlanner(monitor);
         this.HousePlanner = new AnimalHouseRoutePlanner(monitor);
         this.FeedingPlanner = new AnimalFeedingTargetPlanner(monitor);
+        this.ProductPlanner = new AnimalProductTargetPlanner(monitor);
     }
 
     public string? LastStartFailureKey { get; private set; }
@@ -149,6 +153,12 @@ internal sealed class AnimalCareContractExecutionController
                             return;
                         }
                     }
+                    else if (stage.CurrentProductTarget is { } product)
+                    {
+                        stage.AttemptedProductTargets.Add(product.StableKey);
+                        this.BeginProductTransfer(stage, product);
+                        return;
+                    }
                     else
                     {
                         stage.AttemptedAnimalIds.Add(stage.CurrentTarget!.AnimalId);
@@ -158,6 +168,10 @@ internal sealed class AnimalCareContractExecutionController
                 }
                 if (stage.PhaseTicks >= ActionDurationTicks)
                     this.BeginNextOrReturn(stage);
+                break;
+            case AnimalCarePhase.WaitingForProductChestLock:
+                if (stage.PhaseTicks > MaximumProductLockWaitTicks)
+                    this.Complete(stage, false, "harvest.failure.storage-unavailable");
                 break;
             case AnimalCarePhase.Returning:
                 if (stage.Context.Lease.Worker.controller is not null
@@ -187,10 +201,21 @@ internal sealed class AnimalCareContractExecutionController
             stage.Context.Requester.UniqueMultiplayerID, stage.Context.Lease.Worker.Name,
             NamedFarmTask.FarmWork, stage.Context.BillingPreview.EfficiencyMultiplier,
             stage.Phase.ToString(), stage.Plan.ArrivalTile.X, stage.Plan.ArrivalTile.Y,
-            stage.Plan.ArrivalSide, 0, stage.CurrentTarget?.TargetTile.X ?? stage.Plan.ArrivalTile.X,
-            stage.CurrentTarget?.TargetTile.Y ?? stage.Plan.ArrivalTile.Y, stage.Context.BillingPreview.MaximumAuthorizedWage,
-            stage.Context.Lease.StartTime, stage.PettedAnimals + stage.FilledTroughs,
-            Array.Empty<NamedContractCargoState>(), Array.Empty<string>());
+            stage.Plan.ArrivalSide, 0,
+            stage.CurrentProductTarget?.TargetTile.X
+                ?? stage.CurrentTarget?.TargetTile.X
+                ?? stage.Plan.ArrivalTile.X,
+            stage.CurrentProductTarget?.TargetTile.Y
+                ?? stage.CurrentTarget?.TargetTile.Y
+                ?? stage.Plan.ArrivalTile.Y,
+            stage.Context.BillingPreview.MaximumAuthorizedWage,
+            stage.Context.Lease.StartTime,
+            stage.PettedAnimals + stage.FilledTroughs + stage.CollectedProductTargets,
+            stage.ProducedItems.ToArray(),
+            stage.CompletedTransferIds.OrderBy(id => id, StringComparer.Ordinal).ToArray())
+        {
+            HarvestDestination = stage.Context.HarvestDestination
+        };
     }
 
     public NamedContractCompletionState? ConsumeCompletion()
@@ -202,6 +227,8 @@ internal sealed class AnimalCareContractExecutionController
 
     public void OnReturnedToTitle()
     {
+        if (this.ActiveStage?.CurrentProductDestination?.Chest.GetMutex().IsLockHeld() == true)
+            this.ActiveStage.CurrentProductDestination.Chest.GetMutex().ReleaseLock();
         this.ActiveStage = null;
     }
 
@@ -215,6 +242,8 @@ internal sealed class AnimalCareContractExecutionController
     {
         stage.CurrentTarget = target;
         stage.CurrentFeedingTarget = null;
+        stage.CurrentProductTarget = null;
+        stage.CurrentProductDestination = null;
         stage.ActionApplied = false;
         stage.Phase = AnimalCarePhase.Traveling;
         stage.PhaseTicks = 0;
@@ -243,6 +272,7 @@ internal sealed class AnimalCareContractExecutionController
         stage.Context.Lease.Worker.Halt();
         stage.Context.Lease.Worker.faceDirection(
             stage.CurrentFeedingTarget?.FacingDirection
+                ?? stage.CurrentProductTarget?.FacingDirection
                 ?? stage.CurrentTarget!.FacingDirection);
     }
 
@@ -287,6 +317,8 @@ internal sealed class AnimalCareContractExecutionController
     {
         if (stage.CurrentFeedingTarget is { } feeding)
             stage.AttemptedTroughTiles.Add(feeding.TargetTile);
+        else if (stage.CurrentProductTarget is { } product)
+            stage.AttemptedProductTargets.Add(product.StableKey);
         else
             stage.AttemptedAnimalIds.Add(stage.CurrentTarget!.AnimalId);
         stage.Context.Lease.Worker.controller = null;
@@ -341,6 +373,31 @@ internal sealed class AnimalCareContractExecutionController
             return;
         }
 
+        if (stage.WorkLocation is AnimalHouse productHouse)
+        {
+            AnimalProductTargetPlan? product = this.ProductPlanner.TryFindNext(
+                productHouse,
+                stage.Context.Lease.Worker,
+                stage.Context.Lease.Worker.TilePoint,
+                stage.AttemptedProductTargets);
+            if (product is not null)
+            {
+                try
+                {
+                    this.BeginProductTravel(stage, product);
+                }
+                catch (Exception ex)
+                {
+                    this.Monitor.Log(
+                        $"Animal-product route {product.StableKey} failed: {ex.Message}",
+                        LogLevel.Warn);
+                    stage.AttemptedProductTargets.Add(product.StableKey);
+                    this.BeginNextOrReturn(stage);
+                }
+                return;
+            }
+        }
+
         if (stage.WorkLocation is AnimalHouse)
         {
             this.BeginExitHouse(stage);
@@ -390,6 +447,8 @@ internal sealed class AnimalCareContractExecutionController
     {
         stage.CurrentTarget = null;
         stage.CurrentFeedingTarget = target;
+        stage.CurrentProductTarget = null;
+        stage.CurrentProductDestination = null;
         stage.ActionApplied = false;
         stage.Phase = AnimalCarePhase.Traveling;
         stage.PhaseTicks = 0;
@@ -437,9 +496,215 @@ internal sealed class AnimalCareContractExecutionController
         return true;
     }
 
+    private void BeginProductTravel(
+        ActiveAnimalCareStage stage,
+        AnimalProductTargetPlan target)
+    {
+        stage.CurrentTarget = null;
+        stage.CurrentFeedingTarget = null;
+        stage.CurrentProductTarget = target;
+        stage.CurrentProductDestination = null;
+        stage.ActionApplied = false;
+        stage.Phase = AnimalCarePhase.Traveling;
+        stage.PhaseTicks = 0;
+        NPC worker = stage.Context.Lease.Worker;
+        if (worker.TilePoint == target.InteractionTile)
+        {
+            this.OnArrivedAtWork(worker, stage.WorkLocation);
+            return;
+        }
+        if (!FarmNavigationMap.CanBeginPath(
+                stage.WorkLocation, worker, worker.TilePoint, target.Path, out string failure))
+            throw new InvalidOperationException($"Product first step is unsafe: {failure}.");
+        stage.Controller = this.CreateController(
+            stage,
+            target.Path,
+            target.InteractionTile,
+            target.FacingDirection,
+            this.OnArrivedAtWork);
+        stage.Context.Lease.AttachController(stage.Controller);
+    }
+
+    private void BeginProductTransfer(
+        ActiveAnimalCareStage stage,
+        AnimalProductTargetPlan target)
+    {
+        if (stage.WorkLocation is not AnimalHouse house)
+        {
+            this.Complete(stage, false, "contract.failure.target-invalidated");
+            return;
+        }
+
+        if (stage.Context.HarvestDestination == HarvestDestinationMode.RequesterInventory)
+        {
+            Farmer? requester = Game1.GetPlayer(
+                stage.Context.Requester.UniqueMultiplayerID,
+                onlyOnline: true);
+            if (requester is null || !ReferenceEquals(requester.currentLocation, stage.Farm))
+            {
+                this.Complete(stage, false, "harvest.failure.requester-destination-unavailable");
+                return;
+            }
+
+            AnimalProductTransferFailure failure = this.ProductTransfer.TryCommitToRequester(
+                house,
+                target,
+                requester,
+                out Item? delivered);
+            if (failure == AnimalProductTransferFailure.SourceChanged)
+            {
+                this.Monitor.Log(
+                    $"Animal-product target {target.StableKey} changed before commit; skipping it.",
+                    LogLevel.Warn);
+                stage.Phase = AnimalCarePhase.Acting;
+                stage.PhaseTicks = ActionDurationTicks;
+                return;
+            }
+            if (failure != AnimalProductTransferFailure.None || delivered is null)
+            {
+                this.Monitor.Log(
+                    $"Animal-product requester transfer {target.StableKey} failed closed: {failure}.",
+                    LogLevel.Warn);
+                this.Complete(stage, false, "harvest.failure.requester-destination-unavailable");
+                return;
+            }
+
+            this.RecordDeliveredProduct(stage, delivered, toRequester: true);
+            stage.Phase = AnimalCarePhase.Acting;
+            stage.PhaseTicks = ActionDurationTicks;
+            return;
+        }
+
+        Item preview = ItemRegistry.Create(target.QualifiedItemId);
+        preview.Stack = target.Stack;
+        preview.Quality = target.Quality;
+        AnimalProductChestDestination? destination =
+            AnimalProductDestinationPlanner.FindBestChest(stage.Farm, preview);
+        if (destination is null)
+        {
+            this.Complete(stage, false, "harvest.failure.storage-unavailable");
+            return;
+        }
+
+        stage.CurrentProductDestination = destination;
+        stage.Phase = AnimalCarePhase.WaitingForProductChestLock;
+        stage.PhaseTicks = 0;
+        destination.Chest.GetMutex().RequestLock(
+            () => this.OnProductChestLockAcquired(
+                stage.Context.Id,
+                target.StableKey,
+                destination),
+            () => this.OnProductChestLockFailed(
+                stage.Context.Id,
+                target.StableKey,
+                destination));
+    }
+
+    private void OnProductChestLockAcquired(
+        Guid shiftId,
+        string stableKey,
+        AnimalProductChestDestination destination)
+    {
+        ActiveAnimalCareStage? stage = this.ActiveStage;
+        if (stage is null
+            || stage.Context.Id != shiftId
+            || stage.Phase != AnimalCarePhase.WaitingForProductChestLock
+            || stage.CurrentProductTarget?.StableKey != stableKey
+            || !ReferenceEquals(stage.CurrentProductDestination, destination))
+        {
+            if (destination.Chest.GetMutex().IsLockHeld())
+                destination.Chest.GetMutex().ReleaseLock();
+            return;
+        }
+
+        try
+        {
+            Vector2 tile = destination.Tile.ToVector2();
+            if (!stage.Farm.objects.TryGetValue(tile, out StardewValley.Object? current)
+                || !ReferenceEquals(current, destination.Chest)
+                || stage.WorkLocation is not AnimalHouse house)
+            {
+                this.Complete(stage, false, "harvest.failure.storage-unavailable");
+                return;
+            }
+
+            AnimalProductTransferFailure failure = this.ProductTransfer.TryCommitToChest(
+                house,
+                stage.CurrentProductTarget,
+                destination.Chest,
+                stage.Context.Requester,
+                out Item? delivered);
+            if (failure == AnimalProductTransferFailure.SourceChanged)
+            {
+                this.Monitor.Log(
+                    $"Animal-product target {stableKey} changed before locked commit; skipping it.",
+                    LogLevel.Warn);
+                stage.Phase = AnimalCarePhase.Acting;
+                stage.PhaseTicks = ActionDurationTicks;
+                return;
+            }
+            if (failure != AnimalProductTransferFailure.None || delivered is null)
+            {
+                this.Monitor.Log(
+                    $"Animal-product chest transfer {stableKey} failed closed at "
+                    + $"{destination.Tile}: {failure}.",
+                    LogLevel.Warn);
+                this.Complete(stage, false, "harvest.failure.storage-unavailable");
+                return;
+            }
+
+            this.RecordDeliveredProduct(stage, delivered, toRequester: false);
+            stage.Phase = AnimalCarePhase.Acting;
+            stage.PhaseTicks = ActionDurationTicks;
+        }
+        finally
+        {
+            if (destination.Chest.GetMutex().IsLockHeld())
+                destination.Chest.GetMutex().ReleaseLock();
+        }
+    }
+
+    private void OnProductChestLockFailed(
+        Guid shiftId,
+        string stableKey,
+        AnimalProductChestDestination destination)
+    {
+        ActiveAnimalCareStage? stage = this.ActiveStage;
+        if (stage is null
+            || stage.Context.Id != shiftId
+            || stage.Phase != AnimalCarePhase.WaitingForProductChestLock
+            || stage.CurrentProductTarget?.StableKey != stableKey
+            || !ReferenceEquals(stage.CurrentProductDestination, destination))
+            return;
+
+        this.Complete(stage, false, "harvest.failure.storage-unavailable");
+    }
+
+    private void RecordDeliveredProduct(
+        ActiveAnimalCareStage stage,
+        Item delivered,
+        bool toRequester)
+    {
+        string transferId = Guid.NewGuid().ToString("N");
+        stage.CompletedTransferIds.Add(transferId);
+        stage.ProducedItems.Add(new NamedContractCargoState(
+            transferId,
+            delivered.QualifiedItemId,
+            delivered.DisplayName,
+            delivered.Quality,
+            delivered.Stack));
+        stage.CollectedProductTargets++;
+        if (toRequester)
+            stage.PlayerItems += delivered.Stack;
+        else
+            stage.ChestItems += delivered.Stack;
+        stage.WorkLocation.playSound("coin", stage.CurrentProductTarget!.TargetTile.ToVector2());
+    }
+
     private static Point GetCurrentInteractionTile(ActiveAnimalCareStage stage)
     {
         return stage.CurrentFeedingTarget?.InteractionTile
+            ?? stage.CurrentProductTarget?.InteractionTile
             ?? stage.CurrentTarget?.InteractionTile
             ?? throw new InvalidOperationException("Animal-care travel has no current target.");
     }
@@ -501,15 +766,41 @@ internal sealed class AnimalCareContractExecutionController
     {
         if (!ReferenceEquals(this.ActiveStage, stage))
             return;
+        if (stage.CurrentProductDestination?.Chest.GetMutex().IsLockHeld() == true)
+            stage.CurrentProductDestination.Chest.GetMutex().ReleaseLock();
+        int producedItems = stage.ProducedItems.Sum(item => item.Stack);
+        bool placementBalanced = HarvestPlacementAudit.IsBalanced(
+            producedItems,
+            stage.PlayerItems,
+            stage.ChestItems,
+            overflow: 0,
+            quarantine: 0,
+            dropped: 0,
+            unresolved: 0);
+        if (!placementBalanced)
+        {
+            succeeded = false;
+            reason = "harvest.failure.placement-audit";
+        }
+        this.Monitor.Log(
+            $"Animal-product placement audit for shift {stage.Context.Id:N}: "
+            + $"produced={producedItems}, player={stage.PlayerItems}, "
+            + $"chest={stage.ChestItems}, balanced={placementBalanced}.",
+            placementBalanced ? LogLevel.Debug : LogLevel.Error);
         stage.Context.Lease.Worker.controller = null;
         this.ActiveStage = null;
         this.LastCompletion = new NamedContractCompletionState(
             stage.Context.Id.ToString("N"), stage.Context.RequestId,
             stage.Context.Requester.UniqueMultiplayerID, stage.Context.Lease.Worker.Name,
-            NamedFarmTask.FarmWork, succeeded, reason, stage.PettedAnimals + stage.FilledTroughs,
-            0, 0, 0, 0, 0, 0, 0, 0,
-            Array.Empty<NamedContractCargoState>(), Array.Empty<string>(),
-            Array.Empty<NamedContractTransferState>(), Array.Empty<NamedContractTransferState>());
+            NamedFarmTask.FarmWork, succeeded, reason,
+            stage.PettedAnimals + stage.FilledTroughs + stage.CollectedProductTargets,
+            stage.PlayerItems, stage.ChestItems, 0, 0, 0, 0, 0, 0,
+            stage.ProducedItems.ToArray(),
+            stage.CompletedTransferIds.OrderBy(id => id, StringComparer.Ordinal).ToArray(),
+            Array.Empty<NamedContractTransferState>(), Array.Empty<NamedContractTransferState>())
+        {
+            HarvestDestination = stage.Context.HarvestDestination
+        };
     }
 
     private bool FailStart(string key)
@@ -608,6 +899,8 @@ internal sealed class AnimalCareContractExecutionController
             ?? throw new InvalidOperationException("Animal-house exit has no active building.");
         stage.CurrentTarget = null;
         stage.CurrentFeedingTarget = null;
+        stage.CurrentProductTarget = null;
+        stage.CurrentProductDestination = null;
         Stack<Point>? path = this.Planner.TryCreateReturnPath(
             stage.WorkLocation,
             stage.Context.Lease.Worker,
@@ -673,6 +966,8 @@ internal sealed class AnimalCareContractExecutionController
         stage.VisitedBuildingIds.Add(route.BuildingId);
         stage.AttemptedTroughTiles.Clear();
         stage.CurrentFeedingTarget = null;
+        stage.CurrentProductTarget = null;
+        stage.CurrentProductDestination = null;
         stage.CurrentHouseRoute = null;
         stage.Context.Lease.Worker.Halt();
         this.BeginNextOrReturn(stage);
@@ -691,6 +986,7 @@ internal sealed class AnimalCareContractExecutionController
     {
         Traveling,
         Acting,
+        WaitingForProductChestLock,
         TravelingToBuilding,
         TravelingToHouseExit,
         Returning,
@@ -712,16 +1008,24 @@ internal sealed class AnimalCareContractExecutionController
         public AnimalPettingWorkPlan Plan { get; }
         public AnimalPettingTargetPlan? CurrentTarget { get; set; }
         public AnimalFeedingTargetPlan? CurrentFeedingTarget { get; set; }
+        public AnimalProductTargetPlan? CurrentProductTarget { get; set; }
+        public AnimalProductChestDestination? CurrentProductDestination { get; set; }
         public GameLocation WorkLocation { get; set; }
         public AnimalHouseRoutePlan? CurrentHouseRoute { get; set; }
         public HashSet<Guid> VisitedBuildingIds { get; } = new();
         public HashSet<Point> AttemptedTroughTiles { get; } = new();
         public HashSet<long> AttemptedAnimalIds { get; } = new();
+        public HashSet<string> AttemptedProductTargets { get; } = new(StringComparer.Ordinal);
+        public List<NamedContractCargoState> ProducedItems { get; } = new();
+        public HashSet<string> CompletedTransferIds { get; } = new(StringComparer.Ordinal);
         public AnimalCarePhase Phase { get; set; }
         public PathFindController? Controller { get; set; }
         public int PhaseTicks { get; set; }
         public bool ActionApplied { get; set; }
         public int PettedAnimals { get; set; }
         public int FilledTroughs { get; set; }
+        public int CollectedProductTargets { get; set; }
+        public int PlayerItems { get; set; }
+        public int ChestItems { get; set; }
     }
 }

--- a/src/AnimalHouseRoutePlanner.cs
+++ b/src/AnimalHouseRoutePlanner.cs
@@ -125,6 +125,7 @@ internal sealed class AnimalHouseRoutePlanner
     public static bool HasEligibleWork(AnimalHouse house)
     {
         return AnimalFeedingTargetPlanner.HasEmptyTrough(house)
+            || AnimalProductTargetPlanner.HasEligibleWork(house)
             || house.animals.Values.Any(animal =>
             ReferenceEquals(animal.currentLocation, house)
             && AnimalPettingPolicy.GetSkipReason(

--- a/src/AnimalProductTargetPlanner.cs
+++ b/src/AnimalProductTargetPlanner.cs
@@ -135,6 +135,38 @@ internal sealed class AnimalProductTargetPlanner
         return house.objects.Values.Any(item => item.QualifiedItemId == "(BC)165");
     }
 
+    public static bool HasEligibleWork(AnimalHouse house)
+    {
+        if (HasAutoGrabber(house))
+            return false;
+
+        HashSet<string> looseIds = GetLooseProductIds(house);
+        bool hasLooseProduct = house.objects.Values.Any(item =>
+            AnimalProductSourcePolicy.IsEligibleLooseProduct(
+                item.QualifiedItemId,
+                item.bigCraftable.Value,
+                item.CanBeSetDown,
+                looseIds));
+        if (hasLooseProduct)
+            return true;
+
+        return house.animals.Values.Any(animal =>
+        {
+            FarmAnimalData? data = animal.GetAnimalData();
+            return ReferenceEquals(animal.currentLocation, house)
+                && AnimalProducePolicy.TryCreateToolHarvestPlan(
+                    Context.IsMainPlayer,
+                    animal.isAdult(),
+                    animal.currentProduce.Value,
+                    data?.HarvestType == FarmAnimalHarvestType.HarvestWithTool,
+                    data?.HarvestTool,
+                    animal.hasEatenAnimalCracker.Value,
+                    animal.produceQuality.Value,
+                    autoGrabberOwnsProduce: false,
+                    out _) == AnimalCareSkipReason.None;
+        });
+    }
+
     private static HashSet<string> GetLooseProductIds(AnimalHouse house)
     {
         HashSet<string> ids = new(StringComparer.Ordinal);

--- a/src/AnimalProductTransferService.cs
+++ b/src/AnimalProductTransferService.cs
@@ -1,0 +1,345 @@
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.GameData.FarmAnimals;
+using StardewValley.Locations;
+using StardewValley.Objects;
+
+namespace EvilFarmOwner;
+
+internal enum AnimalProductTransferFailure
+{
+    None,
+    SourceChanged,
+    DestinationChanged,
+    InsufficientCapacity,
+    CommitFailed
+}
+
+internal static class AnimalProductCommitPolicy
+{
+    public static AnimalProductTransferFailure EvaluatePreflight(
+        bool sourceUnchanged,
+        bool destinationEligible,
+        int acceptableCapacity,
+        int requestedStack)
+    {
+        if (requestedStack <= 0)
+            throw new ArgumentOutOfRangeException(nameof(requestedStack));
+        if (!sourceUnchanged)
+            return AnimalProductTransferFailure.SourceChanged;
+        if (!destinationEligible)
+            return AnimalProductTransferFailure.DestinationChanged;
+        return acceptableCapacity >= requestedStack
+            ? AnimalProductTransferFailure.None
+            : AnimalProductTransferFailure.InsufficientCapacity;
+    }
+}
+
+internal sealed record AnimalProductChestDestination(
+    Chest Chest,
+    Point Tile,
+    HarvestChestMatchKind MatchKind,
+    int AcceptableCapacity);
+
+internal static class AnimalProductDestinationPlanner
+{
+    public static AnimalProductChestDestination? FindBestChest(Farm farm, Item item)
+    {
+        ArgumentNullException.ThrowIfNull(farm);
+        ArgumentNullException.ThrowIfNull(item);
+
+        List<(HarvestChestOption Option, Chest Chest)> candidates = new();
+        foreach (KeyValuePair<Vector2, StardewValley.Object> pair in farm.objects.Pairs)
+        {
+            if (pair.Value is not Chest chest || !HarvestChestRouter.IsEligibleChest(chest))
+                continue;
+
+            int capacity = HarvestChestRouter.GetAcceptableCapacity(chest, item);
+            if (capacity < item.Stack)
+                continue;
+
+            HarvestChestContents contents = HarvestChestRouter.GetContents(chest, item);
+            HarvestChestMatchKind? match = HarvestChestClassification.Classify(contents);
+            if (!match.HasValue)
+                continue;
+
+            GridPoint tile = new((int)pair.Key.X, (int)pair.Key.Y);
+            candidates.Add((
+                new HarvestChestOption(
+                    tile,
+                    tile,
+                    match.Value,
+                    capacity,
+                    item.Stack,
+                    TravelDistance: 0,
+                    contents),
+                chest));
+        }
+
+        HarvestChestOption? best = HarvestChestRanking.Order(
+            candidates.Select(candidate => candidate.Option)).FirstOrDefault();
+        if (best is null)
+            return null;
+
+        (HarvestChestOption Option, Chest Chest) selected =
+            candidates.First(candidate => candidate.Option == best);
+        return new AnimalProductChestDestination(
+            selected.Chest,
+            new Point(best.ChestTile.X, best.ChestTile.Y),
+            best.MatchKind,
+            best.AcceptableCapacity);
+    }
+}
+
+internal sealed class AnimalProductTransferService
+{
+    public AnimalProductTransferFailure TryCommitToChest(
+        AnimalHouse house,
+        AnimalProductTargetPlan target,
+        Chest chest,
+        Farmer requester,
+        out Item? delivered)
+    {
+        delivered = null;
+        bool sourceUnchanged = TryCreateCurrentProduct(
+            house, target, out Item? product, out FarmAnimal? animal);
+        if (!sourceUnchanged || product is null)
+            return AnimalProductTransferFailure.SourceChanged;
+        bool destinationEligible = HarvestChestRouter.IsEligibleChest(chest)
+            && HarvestChestClassification.Classify(
+                HarvestChestRouter.GetContents(chest, product)).HasValue;
+        AnimalProductTransferFailure preflight = AnimalProductCommitPolicy.EvaluatePreflight(
+            sourceUnchanged,
+            destinationEligible,
+            HarvestChestRouter.GetAcceptableCapacity(chest, product),
+            product.Stack);
+        if (preflight != AnimalProductTransferFailure.None)
+            return preflight;
+
+        InventorySnapshot snapshot = InventorySnapshot.Capture(chest.Items);
+        try
+        {
+            Item? remainder = chest.addItem(product);
+            if (remainder is not null)
+            {
+                snapshot.Restore(chest.Items);
+                return AnimalProductTransferFailure.InsufficientCapacity;
+            }
+
+            product.Stack = target.Stack;
+            if (!TryCommitSource(house, target, animal, product, requester))
+            {
+                snapshot.Restore(chest.Items);
+                return AnimalProductTransferFailure.SourceChanged;
+            }
+
+            delivered = product.getOne();
+            delivered.Stack = target.Stack;
+            delivered.Quality = target.Quality;
+            return AnimalProductTransferFailure.None;
+        }
+        catch
+        {
+            snapshot.Restore(chest.Items);
+            return AnimalProductTransferFailure.CommitFailed;
+        }
+    }
+
+    public AnimalProductTransferFailure TryCommitToRequester(
+        AnimalHouse house,
+        AnimalProductTargetPlan target,
+        Farmer requester,
+        out Item? delivered)
+    {
+        delivered = null;
+        if (!TryCreateCurrentProduct(house, target, out Item? product, out FarmAnimal? animal)
+            || product is null)
+            return AnimalProductTransferFailure.SourceChanged;
+        if (!CanInventoryAcceptCompleteStack(requester, product))
+            return AnimalProductTransferFailure.InsufficientCapacity;
+
+        InventorySnapshot snapshot = InventorySnapshot.Capture(requester.Items);
+        try
+        {
+            Item? remainder = requester.addItemToInventory(product);
+            if (remainder is not null)
+            {
+                snapshot.Restore(requester.Items);
+                return AnimalProductTransferFailure.InsufficientCapacity;
+            }
+
+            product.Stack = target.Stack;
+            if (!TryCommitSource(house, target, animal, product, requester))
+            {
+                snapshot.Restore(requester.Items);
+                return AnimalProductTransferFailure.SourceChanged;
+            }
+
+            delivered = product.getOne();
+            delivered.Stack = target.Stack;
+            delivered.Quality = target.Quality;
+            return AnimalProductTransferFailure.None;
+        }
+        catch
+        {
+            snapshot.Restore(requester.Items);
+            return AnimalProductTransferFailure.CommitFailed;
+        }
+    }
+
+    public static bool CanInventoryAcceptCompleteStack(Farmer requester, Item item)
+    {
+        ArgumentNullException.ThrowIfNull(requester);
+        ArgumentNullException.ThrowIfNull(item);
+        if (item.IsRecipe
+            || item.QualifiedItemId is "(O)73" or "(O)930" or "(O)102" or "(O)858" or "(O)GoldCoin")
+            return true;
+
+        for (int index = 0; index < requester.MaxItems && index < requester.Items.Count; index++)
+        {
+            Item? existing = requester.Items[index];
+            if (existing is null)
+                return true;
+            if (existing.canStackWith(item)
+                && existing.Stack + item.Stack <= existing.maximumStackSize())
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryCreateCurrentProduct(
+        AnimalHouse house,
+        AnimalProductTargetPlan target,
+        out Item? product,
+        out FarmAnimal? animal)
+    {
+        product = null;
+        animal = null;
+        if (target.Kind == AnimalProductTargetKind.LooseOvernightProduct)
+        {
+            Vector2 tile = target.TargetTile.ToVector2();
+            if (!house.objects.TryGetValue(tile, out StardewValley.Object? source)
+                || source.QualifiedItemId != target.QualifiedItemId
+                || source.Stack != target.Stack
+                || source.Quality != target.Quality)
+                return false;
+
+            product = source.getOne();
+            product.Stack = source.Stack;
+            product.Quality = source.Quality;
+            return true;
+        }
+
+        if (!target.AnimalId.HasValue
+            || !house.animals.TryGetValue(target.AnimalId.Value, out animal)
+            || !ReferenceEquals(animal.currentLocation, house))
+            return false;
+
+        FarmAnimalData? data = animal.GetAnimalData();
+        AnimalCareSkipReason reason = AnimalProducePolicy.TryCreateToolHarvestPlan(
+            Context.IsMainPlayer,
+            animal.isAdult(),
+            animal.currentProduce.Value,
+            data?.HarvestType == FarmAnimalHarvestType.HarvestWithTool,
+            data?.HarvestTool,
+            animal.hasEatenAnimalCracker.Value,
+            animal.produceQuality.Value,
+            autoGrabberOwnsProduce: false,
+            out AnimalProducePlan? plan);
+        if (reason != AnimalCareSkipReason.None
+            || plan is null
+            || plan.QualifiedItemId != target.QualifiedItemId
+            || plan.Stack != target.Stack
+            || plan.Quality != target.Quality
+            || plan.RequiredTool != target.RequiredTool)
+            return false;
+
+        StardewValley.Object created = ItemRegistry.Create<StardewValley.Object>(plan.QualifiedItemId);
+        created.CanBeSetDown = false;
+        created.Stack = plan.Stack;
+        created.Quality = plan.Quality;
+        product = created;
+        return true;
+    }
+
+    private static bool TryCommitSource(
+        AnimalHouse house,
+        AnimalProductTargetPlan target,
+        FarmAnimal? animal,
+        Item product,
+        Farmer requester)
+    {
+        if (target.Kind == AnimalProductTargetKind.LooseOvernightProduct)
+        {
+            Vector2 tile = target.TargetTile.ToVector2();
+            if (!house.objects.TryGetValue(tile, out StardewValley.Object? source)
+                || source.QualifiedItemId != target.QualifiedItemId
+                || source.Stack != target.Stack
+                || source.Quality != target.Quality)
+                return false;
+            return ReferenceEquals(house.removeObject(tile, showDestroyedObject: false), source);
+        }
+
+        if (animal is null
+            || animal.currentProduce.Value is null
+            || !ReferenceEquals(animal.currentLocation, house))
+            return false;
+
+        string previousProduce = animal.currentProduce.Value;
+        int previousFriendship = animal.friendshipTowardFarmer.Value;
+        try
+        {
+            animal.currentProduce.Value = null;
+            animal.friendshipTowardFarmer.Value = Math.Min(1000, previousFriendship + 5);
+            animal.ReloadTextureIfNeeded();
+            animal.HandleStatsOnProduceCollected(product, (uint)product.Stack);
+            requester.gainExperience(0, 5);
+            return true;
+        }
+        catch
+        {
+            animal.currentProduce.Value = previousProduce;
+            animal.friendshipTowardFarmer.Value = previousFriendship;
+            animal.ReloadTextureIfNeeded();
+            throw;
+        }
+    }
+
+    private sealed class InventorySnapshot
+    {
+        private readonly Item?[] Items;
+        private readonly int[] Stacks;
+
+        private InventorySnapshot(Item?[] items, int[] stacks)
+        {
+            this.Items = items;
+            this.Stacks = stacks;
+        }
+
+        public static InventorySnapshot Capture(IList<Item> inventory)
+        {
+            Item?[] items = inventory.Cast<Item?>().ToArray();
+            return new InventorySnapshot(
+                items,
+                items.Select(item => item?.Stack ?? 0).ToArray());
+        }
+
+        public void Restore(IList<Item> inventory)
+        {
+            while (inventory.Count > this.Items.Length)
+                inventory.RemoveAt(inventory.Count - 1);
+            while (inventory.Count < this.Items.Length)
+                inventory.Add(null!);
+
+            for (int index = 0; index < this.Items.Length; index++)
+            {
+                Item? item = this.Items[index];
+                if (item is not null)
+                    item.Stack = this.Stacks[index];
+                inventory[index] = item!;
+            }
+        }
+    }
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -23,6 +23,7 @@ List<(string Name, Action Test)> tests = new()
     ("animal tool produce readiness", TestAnimalToolProduceReadiness),
     ("animal loose product ownership", TestAnimalLooseProductOwnership),
     ("animal product route ordering", TestAnimalProductRouteOrdering),
+    ("animal product commit preflight", TestAnimalProductCommitPreflight),
     ("recurring contract state validation", TestRecurringContractStateValidation),
     ("recurring contract candidate pool", TestRecurringContractCandidatePool),
     ("recurring contract ranking", TestRecurringContractRanking),
@@ -459,6 +460,20 @@ static void TestAnimalProductRouteOrdering()
     Equal("loose:c", ordered[0].StableKey);
     Equal("tool:a", ordered[1].StableKey);
     Equal("tool:b", ordered[2].StableKey);
+}
+
+static void TestAnimalProductCommitPreflight()
+{
+    Equal(AnimalProductTransferFailure.None,
+        AnimalProductCommitPolicy.EvaluatePreflight(true, true, 2, 2));
+    Equal(AnimalProductTransferFailure.SourceChanged,
+        AnimalProductCommitPolicy.EvaluatePreflight(false, true, 99, 1));
+    Equal(AnimalProductTransferFailure.DestinationChanged,
+        AnimalProductCommitPolicy.EvaluatePreflight(true, false, 99, 1));
+    Equal(AnimalProductTransferFailure.InsufficientCapacity,
+        AnimalProductCommitPolicy.EvaluatePreflight(true, true, 1, 2));
+    Throws<ArgumentOutOfRangeException>(() =>
+        AnimalProductCommitPolicy.EvaluatePreflight(true, true, 0, 0));
 }
 
 static void TestRecurringContractStateValidation()


### PR DESCRIPTION
## Summary

- collect allowlisted loose barn/coop products plus tool-ready milk and wool during complete shifts
- revalidate and commit the exact source into the contract-selected requester inventory or deterministic classified chest
- lock chest commits, roll back destination mutations on failure, preserve vanilla produce stats/friendship/XP, and keep auto-grabber rooms excluded
- report product destinations and enforce a final placement-conservation audit
- update bilingual player documentation and the animal-operation matrix

## Linked Issue

Closes #86

## Change Type

- [x] `feat`: user-facing feature
- [ ] `fix`: bug fix
- [x] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [x] `test`: test or validation work

## Validation

- [x] Built locally with `dotnet build -c Release` (0 warnings, 0 errors)
- [ ] Launched with SMAPI (not run; maintainer requested no game acceptance)
- [ ] Tested in a save file (deferred by maintainer)
- [x] Multiplayer impact considered (all world, item, animal, stats, and chest mutations remain host-owned; chest writes use the existing mutex)
- [x] Documentation updated
- [x] `dotnet run -c Release --project tests/EvilFarmOwner.LogicTests.csproj` (96/96 passed)
- [x] source checks: shell syntax, JSON, translation-key parity, and `git diff --check`

## Notes

Auto-grabber rooms remain deliberately excluded because their internal inventories need a separate locked-container contract. No game process was launched for this PR.