### PR TITLE
feat(harvest): collect safe ready machine outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added conservative collection for simple ready vanilla machines, preserving exact output, harvest stats, experience, sprite/reset state, and lossless destinations while excluding collect-time recalculation and continuation machines.
 - Added lossless collection of eggs and other resident-animal loose products plus tool-ready milk and wool, with exact vanilla produce state, locked deterministic destinations, rollback on failed commits, and auto-grabber exclusion.
 - Added safe barn/coop human-door transitions, indoor animal petting, and finite-silo-hay trough feeding to complete shifts.
 - Added host-owned, non-destructive outdoor animal petting to complete shifts, with stable animal identities, daily idempotency, worker movement, and final reconciliation.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 
 - 浇灌所有能够安全到达的缺水作物；
 - 收获所有能够安全到达的成熟作物，以及树上已经就绪的普通或重型树液采集器产物；
+- 收取能够安全完成原版状态重置的普通生产机器成品；
 - 进入畜棚和鸡舍，抚摸动物、用自有干草补满食槽，并收集鸡蛋、牛奶和羊毛；
 - 按箱子里已有的物品整理普通箱子；
 - 设置每天自动尝试执行的完整农活班次。
@@ -132,7 +133,7 @@ Mods/EvilFarmOwner/config.json
 
 ### 当前限制
 
-- 暂不支持清理杂物、播种、施肥、补充普通生产机器或自动出售；动物自动采集器的内部箱子也不会被本 Mod 接管。
+- 暂不支持清理杂物、播种、施肥、自动补充机器原料或自动出售；需要在收取时重新计算或自动续产的机器，以及动物自动采集器内部箱子，不会被本 Mod 接管。
 - 暂不支持特殊箱子和其他 Mod 添加的箱子。
 - 自动合同与手动雇佣执行同一套完整班次，包括当前可执行的箱子整理。
 - 个别农场布局可能没有安全路线；这种情况下合同会拒绝开始或提前停止。
@@ -152,6 +153,7 @@ Each hire automatically works through these stages in order:
 
 - water every safely reachable dry crop;
 - harvest every safely reachable mature crop and every ready normal or heavy tree tapper;
+- collect outputs from simple ready vanilla machines whose collection state can be preserved safely;
 - enter barns and coops to pet animals, fill troughs from owned silo hay, and collect eggs, milk, and wool;
 - organize ordinary farm chests based on their existing contents;
 - set up a daily automatic complete farm-work shift.
@@ -212,7 +214,7 @@ Most players only need the `K` key. The extra commands help inspect recent work 
 
 ### Current limitations
 
-- No debris clearing, planting, fertilizing, ordinary machine collection/refilling, or automatic shipping. Auto-grabber contents are deliberately excluded from livestock collection.
+- No debris clearing, planting, fertilizing, automatic machine refilling, or automatic shipping. Machines which recalculate or restart on collection and auto-grabber contents are deliberately excluded.
 - No special or modded chest support.
 - Automatic contracts use the same harvest, watering, and chest-sorting sequence as manual hiring.
 - Some farm layouts may not provide a safe route; the contract will refuse or stop instead of breaking objects.

--- a/docs/HARVEST_SOURCE_MATRIX.md
+++ b/docs/HARVEST_SOURCE_MATRIX.md
@@ -9,12 +9,13 @@ This matrix prevents the complete shift from treating every object with a held i
 | Mature crops | `Crop.harvest` and crop removal/regrowth result | Exact captured output and by-products enter the lossless destination pipeline. |
 | Normal and heavy tree tappers | Clear ready output, then call the tree's tapper rescheduler | Exact output enters the lossless destination pipeline; rollback restores the ready item if rescheduling fails. |
 | Fruit trees | Clear the tree's fruit list once after capturing every non-null fruit slot | Stored item, stack, and quality are preserved. Lightning-struck trees produce one coal per occupied fruit slot like vanilla. |
+| Simple ready vanilla machines | Clear the held output and ready/display state, reset the sprite, apply declared harvest stats and experience, and never auto-load another input | Limited to exact vanilla `Object` machines with numeric IDs and no collect-time recalculation or `OutputCollected` continuation rule. Exact output metadata enters the existing lossless destination pipeline. |
 
 ## Requires a dedicated implementation
 
 | Source | Why generic `heldObject` removal is unsafe |
 | --- | --- |
-| Data-driven machines, including bee houses, mushroom boxes/logs, lightning rods, solar panels, statues, and similar producers | Vanilla collection can recalculate output, update stats and experience, reset sprites, run `OutputCollected` rules, or start another output. Each enabled machine must preserve those rules while deliberately avoiding automatic refill. |
+| Stateful data-driven machines | Machines with collect-time recalculation or `OutputCollected` continuation rules can replace output, consume retained input, or immediately start another cycle. They remain excluded until that continuation can be rolled back exactly. |
 | Crab pots | Collection clears bait/readiness, records caught fish, applies profession/book effects, grants fishing experience, and may change stack size. Refill remains a separate future action. |
 | Fish ponds | Collection clears the building output and grants fishing experience based on value. The interaction tile and building-owned output need a building-target route. |
 | Berry and tea bushes | Output count, quality, experience, mutex behavior, and special walnut bushes depend on bush type and the requesting farmer. Special/map bushes must be excluded explicitly. |
@@ -28,3 +29,7 @@ This matrix prevents the complete shift from treating every object with a held i
 - Auto-grabber contents; those belong to the animal-care/storage design and require the chest mutex.
 - Incubators, hatching devices, quest rewards, choice menus, buffs, arcade/furniture interactions, and other non-item interactions.
 - Modded machines without an explicit compatibility contract.
+
+## Simple-machine boundary
+
+The generic ready-machine collector deliberately accepts only the subset whose vanilla collection is a finite clear-and-report transition. It excludes subclasses, non-numeric/modded IDs, incubators, tappers, chest-backed machines, collect-time recalculation, and any output-collected continuation rule. This keeps crystalariums and other retained-input machines from being cleared without correctly restarting their cycle. Automatic input loading is never called.

--- a/src/ContractHarvestCollector.cs
+++ b/src/ContractHarvestCollector.cs
@@ -64,3 +64,30 @@ internal static class FruitTreeHarvestSemantics
         return struckByLightning;
     }
 }
+
+internal static class MachineHarvestSemantics
+{
+    public static bool IsReadyTarget(
+        bool isExactVanillaObject,
+        bool hasNumericVanillaId,
+        bool isBigCraftable,
+        bool isReady,
+        bool hasPlainObjectOutput,
+        bool hasMachineData,
+        bool isIncubator,
+        bool isTapper,
+        bool recalculatesOnCollect,
+        bool hasOutputCollectedRule)
+    {
+        return isExactVanillaObject
+            && hasNumericVanillaId
+            && isBigCraftable
+            && isReady
+            && hasPlainObjectOutput
+            && hasMachineData
+            && !isIncubator
+            && !isTapper
+            && !recalculatesOnCollect
+            && !hasOutputCollectedRule;
+    }
+}

--- a/src/HarvestTargetPlanner.cs
+++ b/src/HarvestTargetPlanner.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewValley;
+using StardewValley.GameData.Machines;
 using StardewValley.Locations;
 using StardewValley.TerrainFeatures;
 
@@ -19,7 +20,8 @@ internal enum HarvestTargetKind
 {
     Crop,
     Tapper,
-    FruitTree
+    FruitTree,
+    Machine
 }
 
 internal sealed record HarvestTargetPlan(
@@ -265,6 +267,31 @@ internal sealed class HarvestTargetPlanner
             fruitSlots);
     }
 
+    public static bool IsReadySupportedMachine(GameLocation location, Vector2 tile)
+    {
+        if (!location.objects.TryGetValue(tile, out StardewValley.Object? machine))
+            return false;
+
+        MachineData? data = machine.GetMachineData();
+        bool hasRecalculateOnCollectRule = data?.OutputRules?.Any(
+            rule => rule.RecalculateOnCollect) == true;
+        bool hasOutputCollectedRule = data?.OutputRules?.Any(rule =>
+            rule.Triggers?.Any(trigger =>
+                trigger.Trigger.HasFlag(MachineOutputTrigger.OutputCollected)) == true) == true;
+        return MachineHarvestSemantics.IsReadyTarget(
+            machine.GetType() == typeof(StardewValley.Object),
+            int.TryParse(machine.ItemId, out _),
+            machine.bigCraftable.Value,
+            machine.readyForHarvest.Value,
+            machine.heldObject.Value is StardewValley.Object
+                and not StardewValley.Objects.Chest,
+            data is not null,
+            data?.IsIncubator == true,
+            machine.IsTapper(),
+            hasRecalculateOnCollectRule,
+            hasOutputCollectedRule);
+    }
+
     public static HarvestTargetKind? GetSupportedTargetKind(GameLocation location, Vector2 tile)
     {
         if (IsMatureSupportedCrop(location, tile))
@@ -273,6 +300,8 @@ internal sealed class HarvestTargetPlanner
             return HarvestTargetKind.Tapper;
         if (IsReadySupportedFruitTree(location, tile))
             return HarvestTargetKind.FruitTree;
+        if (IsReadySupportedMachine(location, tile))
+            return HarvestTargetKind.Machine;
         return null;
     }
 

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Xml;
 using System.Xml.Serialization;
 using StardewValley;
+using StardewValley.GameData.Machines;
 using StardewValley.Inventories;
 using StardewValley.ItemTypeDefinitions;
 using StardewValley.Locations;
@@ -893,6 +894,7 @@ internal sealed class HarvestingContractExecutionController
             HarvestTargetKind.Crop => this.TryApplyCropHarvest(contract),
             HarvestTargetKind.Tapper => this.TryApplyTapperHarvest(contract),
             HarvestTargetKind.FruitTree => this.TryApplyFruitTreeHarvest(contract),
+            HarvestTargetKind.Machine => this.TryApplyMachineHarvest(contract),
             _ => false
         };
     }
@@ -997,6 +999,50 @@ internal sealed class HarvestingContractExecutionController
             this.CaptureHarvestItem(contract, item, producesCoal ? "lightning-struck fruit tree" : "fruit tree");
         this.ShowHarvestedItem(contract, collected[0]);
         return true;
+    }
+
+    private bool TryApplyMachineHarvest(ActiveHarvestContract contract)
+    {
+        Vector2 targetTile = contract.CurrentTarget.TargetTile.ToVector2();
+        if (!HarvestTargetPlanner.IsReadySupportedMachine(contract.Farm, targetTile)
+            || !contract.Farm.objects.TryGetValue(
+                targetTile,
+                out StardewValley.Object? machine)
+            || machine.heldObject.Value is not { } output
+            || machine.GetMachineData() is not { } data)
+            return false;
+
+        Item collected = output.getOne();
+        collected.Stack = output.Stack;
+        collected.Quality = output.Quality;
+
+        machine.heldObject.Value = null;
+        machine.readyForHarvest.Value = false;
+        machine.showNextIndex.Value = false;
+        machine.ResetParentSheetIndex();
+
+        MachineDataUtility.UpdateStats(
+            data.StatsToIncrementWhenHarvested,
+            collected,
+            collected.Stack);
+        ApplyMachineHarvestExperience(data.ExperienceGainOnHarvest, contract.Requester);
+        this.CaptureHarvestItem(contract, collected, $"machine {machine.QualifiedItemId}");
+        this.ShowHarvestedItem(contract, collected);
+        return true;
+    }
+
+    private static void ApplyMachineHarvestExperience(string? experience, Farmer requester)
+    {
+        if (string.IsNullOrWhiteSpace(experience))
+            return;
+
+        string[] fields = experience.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        for (int index = 0; index + 1 < fields.Length; index += 2)
+        {
+            int skill = Farmer.getSkillNumberFromName(fields[index]);
+            if (skill >= 0 && int.TryParse(fields[index + 1], out int amount))
+                requester.gainExperience(skill, amount);
+        }
     }
 
     private void CaptureHarvestItem(ActiveHarvestContract contract, Item item, string source)

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -81,6 +81,7 @@ List<(string Name, Action Test)> tests = new()
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("ready tapper target semantics", TestReadyTapperTargetSemantics),
     ("ready fruit-tree target semantics", TestReadyFruitTreeTargetSemantics),
+    ("ready machine target semantics", TestReadyMachineTargetSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
     ("harvest transfer replay protection", TestHarvestTransferReplayProtection),
     ("harvest placement conservation", TestHarvestPlacementConservation),
@@ -1875,6 +1876,24 @@ static void TestReadyFruitTreeTargetSemantics()
         fruitSlots: 0));
     Equal(false, FruitTreeHarvestSemantics.ProducesCoal(struckByLightning: false));
     Equal(true, FruitTreeHarvestSemantics.ProducesCoal(struckByLightning: true));
+}
+
+static void TestReadyMachineTargetSemantics()
+{
+    Equal(true, MachineHarvestSemantics.IsReadyTarget(
+        true, true, true, true, true, true, false, false, false, false));
+    Equal(false, MachineHarvestSemantics.IsReadyTarget(
+        false, true, true, true, true, true, false, false, false, false));
+    Equal(false, MachineHarvestSemantics.IsReadyTarget(
+        true, false, true, true, true, true, false, false, false, false));
+    Equal(false, MachineHarvestSemantics.IsReadyTarget(
+        true, true, true, true, true, true, true, false, false, false));
+    Equal(false, MachineHarvestSemantics.IsReadyTarget(
+        true, true, true, true, true, true, false, true, false, false));
+    Equal(false, MachineHarvestSemantics.IsReadyTarget(
+        true, true, true, true, true, true, false, false, true, false));
+    Equal(false, MachineHarvestSemantics.IsReadyTarget(
+        true, true, true, true, true, true, false, false, false, true));
 }
 
 static void TestHarvestPlacementConservation()


### PR DESCRIPTION
## Summary

- add simple ready vanilla machines to complete-shift harvest planning
- preserve exact output metadata, ready/display reset, harvest stats, and declared experience
- keep automatic refill disabled
- fail closed for subclasses, modded/non-numeric IDs, chest-backed machines, incubators, tappers, collect-time recalculation, and `OutputCollected` continuation rules
- document the enabled boundary and remaining stateful-machine work

## Linked Issue

Part of #85

## Change Type

- [x] `feat`: user-facing feature
- [x] `docs`: documentation
- [x] `test`: deterministic policy coverage

## Validation

- [x] `dotnet build -c Release` (0 warnings, 0 errors)
- [x] `dotnet run -c Release --project tests/EvilFarmOwner.LogicTests.csproj` (97/97 passed)
- [x] `git diff --check`
- [x] Multiplayer impact considered: source mutation and output ownership remain host-owned
- [ ] SMAPI/save test deferred by maintainer request

## Notes

This PR intentionally does not close #85. Crab pots, fish ponds, bushes, and stateful collect-time machines remain dedicated follow-up slices. No game process was launched.