### PR TITLE
feat(harvest): collect ready crab pots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added lossless crab-pot collection with the original deterministic Crabbing Book bonus, fish records, fishing experience, bait/readiness reset, and no automatic rebaiting.
 - Added conservative collection for simple ready vanilla machines, preserving exact output, harvest stats, experience, sprite/reset state, and lossless destinations while excluding collect-time recalculation and continuation machines.
 - Added lossless collection of eggs and other resident-animal loose products plus tool-ready milk and wool, with exact vanilla produce state, locked deterministic destinations, rollback on failed commits, and auto-grabber exclusion.
 - Added safe barn/coop human-door transitions, indoor animal petting, and finite-silo-hay trough feeding to complete shifts.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - 浇灌所有能够安全到达的缺水作物；
 - 收获所有能够安全到达的成熟作物，以及树上已经就绪的普通或重型树液采集器产物；
 - 收取能够安全完成原版状态重置的普通生产机器成品；
+- 收取已就绪蟹笼的产物并保留原版收集加成，但不会自动补饵；
 - 进入畜棚和鸡舍，抚摸动物、用自有干草补满食槽，并收集鸡蛋、牛奶和羊毛；
 - 按箱子里已有的物品整理普通箱子；
 - 设置每天自动尝试执行的完整农活班次。
@@ -154,6 +155,7 @@ Each hire automatically works through these stages in order:
 - water every safely reachable dry crop;
 - harvest every safely reachable mature crop and every ready normal or heavy tree tapper;
 - collect outputs from simple ready vanilla machines whose collection state can be preserved safely;
+- collect ready crab pots with vanilla catch bonuses and records, without automatic rebaiting;
 - enter barns and coops to pet animals, fill troughs from owned silo hay, and collect eggs, milk, and wool;
 - organize ordinary farm chests based on their existing contents;
 - set up a daily automatic complete farm-work shift.

--- a/docs/HARVEST_SOURCE_MATRIX.md
+++ b/docs/HARVEST_SOURCE_MATRIX.md
@@ -10,13 +10,13 @@ This matrix prevents the complete shift from treating every object with a held i
 | Normal and heavy tree tappers | Clear ready output, then call the tree's tapper rescheduler | Exact output enters the lossless destination pipeline; rollback restores the ready item if rescheduling fails. |
 | Fruit trees | Clear the tree's fruit list once after capturing every non-null fruit slot | Stored item, stack, and quality are preserved. Lightning-struck trees produce one coal per occupied fruit slot like vanilla. |
 | Simple ready vanilla machines | Clear the held output and ready/display state, reset the sprite, apply declared harvest stats and experience, and never auto-load another input | Limited to exact vanilla `Object` machines with numeric IDs and no collect-time recalculation or `OutputCollected` continuation rule. Exact output metadata enters the existing lossless destination pipeline. |
+| Crab pots | Preserve the deterministic Crabbing Book double-catch rule, caught-fish record/length, five fishing XP, consumed bait, lid/readiness state, and short removal guard | Collect the existing exact output through the lossless destination pipeline. Never refill bait automatically. |
 
 ## Requires a dedicated implementation
 
 | Source | Why generic `heldObject` removal is unsafe |
 | --- | --- |
 | Stateful data-driven machines | Machines with collect-time recalculation or `OutputCollected` continuation rules can replace output, consume retained input, or immediately start another cycle. They remain excluded until that continuation can be rolled back exactly. |
-| Crab pots | Collection clears bait/readiness, records caught fish, applies profession/book effects, grants fishing experience, and may change stack size. Refill remains a separate future action. |
 | Fish ponds | Collection clears the building output and grants fishing experience based on value. The interaction tile and building-owned output need a building-target route. |
 | Berry and tea bushes | Output count, quality, experience, mutex behavior, and special walnut bushes depend on bush type and the requesting farmer. Special/map bushes must be excluded explicitly. |
 | Farm-building interiors | Barns, coops, sheds, caves, and greenhouse-like locations need location-aware entrances, doors, route ownership, and return behavior before their contents can join a main-farm shift. |

--- a/src/ContractHarvestCollector.cs
+++ b/src/ContractHarvestCollector.cs
@@ -91,3 +91,31 @@ internal static class MachineHarvestSemantics
             && !hasOutputCollectedRule;
     }
 }
+
+internal static class CrabPotHarvestSemantics
+{
+    public static bool IsReadyTarget(
+        bool showingCatch,
+        bool readyForHarvest,
+        bool hasOutput)
+    {
+        return showingCatch && readyForHarvest && hasOutput;
+    }
+
+    public static int GetOutputStack(
+        int baseStack,
+        bool hasCrabbingBook,
+        double deterministicRoll,
+        bool destinationAcceptsDouble)
+    {
+        if (baseStack <= 0)
+            throw new ArgumentOutOfRangeException(nameof(baseStack));
+        if (deterministicRoll < 0 || deterministicRoll >= 1)
+            throw new ArgumentOutOfRangeException(nameof(deterministicRoll));
+        return hasCrabbingBook
+            && deterministicRoll < 0.25
+            && destinationAcceptsDouble
+                ? checked(baseStack * 2)
+                : baseStack;
+    }
+}

--- a/src/HarvestTargetPlanner.cs
+++ b/src/HarvestTargetPlanner.cs
@@ -3,6 +3,7 @@ using StardewModdingAPI;
 using StardewValley;
 using StardewValley.GameData.Machines;
 using StardewValley.Locations;
+using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
 
 namespace EvilFarmOwner;
@@ -21,7 +22,8 @@ internal enum HarvestTargetKind
     Crop,
     Tapper,
     FruitTree,
-    Machine
+    Machine,
+    CrabPot
 }
 
 internal sealed record HarvestTargetPlan(
@@ -292,6 +294,16 @@ internal sealed class HarvestTargetPlanner
             hasOutputCollectedRule);
     }
 
+    public static bool IsReadySupportedCrabPot(GameLocation location, Vector2 tile)
+    {
+        return location.objects.TryGetValue(tile, out StardewValley.Object? value)
+            && value is CrabPot pot
+            && CrabPotHarvestSemantics.IsReadyTarget(
+                pot.tileIndexToShow == 714,
+                pot.readyForHarvest.Value,
+                pot.heldObject.Value is not null);
+    }
+
     public static HarvestTargetKind? GetSupportedTargetKind(GameLocation location, Vector2 tile)
     {
         if (IsMatureSupportedCrop(location, tile))
@@ -300,6 +312,8 @@ internal sealed class HarvestTargetPlanner
             return HarvestTargetKind.Tapper;
         if (IsReadySupportedFruitTree(location, tile))
             return HarvestTargetKind.FruitTree;
+        if (IsReadySupportedCrabPot(location, tile))
+            return HarvestTargetKind.CrabPot;
         if (IsReadySupportedMachine(location, tile))
             return HarvestTargetKind.Machine;
         return null;

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using System.Globalization;
+using System.Reflection;
 using System.Text.Json;
 using System.Xml;
 using System.Xml.Serialization;
@@ -10,6 +11,7 @@ using StardewValley.Inventories;
 using StardewValley.ItemTypeDefinitions;
 using StardewValley.Locations;
 using StardewValley.Network;
+using StardewValley.Objects;
 using StardewValley.Pathfinding;
 using StardewValley.TerrainFeatures;
 
@@ -895,6 +897,7 @@ internal sealed class HarvestingContractExecutionController
             HarvestTargetKind.Tapper => this.TryApplyTapperHarvest(contract),
             HarvestTargetKind.FruitTree => this.TryApplyFruitTreeHarvest(contract),
             HarvestTargetKind.Machine => this.TryApplyMachineHarvest(contract),
+            HarvestTargetKind.CrabPot => this.TryApplyCrabPotHarvest(contract),
             _ => false
         };
     }
@@ -1043,6 +1046,98 @@ internal sealed class HarvestingContractExecutionController
             if (skill >= 0 && int.TryParse(fields[index + 1], out int amount))
                 requester.gainExperience(skill, amount);
         }
+    }
+
+    private bool TryApplyCrabPotHarvest(ActiveHarvestContract contract)
+    {
+        Vector2 targetTile = contract.CurrentTarget.TargetTile.ToVector2();
+        if (!HarvestTargetPlanner.IsReadySupportedCrabPot(contract.Farm, targetTile)
+            || !contract.Farm.objects.TryGetValue(targetTile, out StardewValley.Object? value)
+            || value is not CrabPot pot
+            || pot.heldObject.Value is not { } output)
+            return false;
+
+        Item collected = output.getOne();
+        collected.Stack = output.Stack;
+        collected.Quality = output.Quality;
+        FieldInfo? ignoreRemovalTimer = typeof(CrabPot).GetField(
+            "ignoreRemovalTimer",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        if (ignoreRemovalTimer is null)
+            return false;
+
+        bool hasBook = contract.Requester.stats.Get("Book_Crabbing") != 0;
+        double roll = Utility.CreateDaySaveRandom(
+            Game1.uniqueIDForThisGame,
+            Game1.stats.DaysPlayed * 77,
+            targetTile.X * 777f + targetTile.Y).NextDouble();
+        Item doubled = collected.getOne();
+        doubled.Stack = checked(collected.Stack * 2);
+        bool destinationAcceptsDouble = this.CanHarvestDestinationAccept(
+            contract,
+            doubled);
+        collected.Stack = CrabPotHarvestSemantics.GetOutputStack(
+            collected.Stack,
+            hasBook,
+            roll,
+            destinationAcceptsDouble);
+
+        int? caughtLength = null;
+        if (DataLoader.Fish(Game1.content).TryGetValue(collected.ItemId, out string? fishData))
+        {
+            string[] fields = fishData.Split('/');
+            int minimumLength = fields.Length <= 5 ? 1 : Convert.ToInt32(fields[5]);
+            int maximumLength = fields.Length > 5 ? Convert.ToInt32(fields[6]) : 10;
+            caughtLength = Game1.random.Next(minimumLength, maximumLength + 1);
+        }
+
+        ignoreRemovalTimer.SetValue(pot, 750);
+        pot.heldObject.Value = null;
+        pot.readyForHarvest.Value = false;
+        pot.tileIndexToShow = 710;
+        pot.lidFlapping = true;
+        pot.lidFlapTimer = 60f;
+        pot.bait.Value = null;
+        pot.shake = Vector2.Zero;
+        pot.shakeTimer = 0f;
+        if (caughtLength.HasValue)
+        {
+            contract.Requester.caughtFish(
+                collected.QualifiedItemId,
+                caughtLength.Value,
+                from_fish_pond: false,
+                collected.Stack);
+        }
+        contract.Requester.gainExperience(1, 5);
+        contract.Farm.playSound("fishingRodBend", targetTile);
+        this.CaptureHarvestItem(contract, collected, "crab pot");
+        this.ShowHarvestedItem(contract, collected);
+        return true;
+    }
+
+    private bool CanHarvestDestinationAccept(
+        ActiveHarvestContract contract,
+        Item item)
+    {
+        if (contract.DestinationMode == HarvestDestinationMode.RequesterInventory)
+        {
+            Farmer? requester = Game1.GetPlayer(
+                contract.Requester.UniqueMultiplayerID,
+                onlyOnline: true);
+            return requester is not null
+                && ReferenceEquals(requester.currentLocation, contract.Farm)
+                && AnimalProductTransferService.CanInventoryAcceptCompleteStack(
+                    requester,
+                    item);
+        }
+
+        return this.ChestRouter.FindBestRoute(
+            contract.Farm,
+            contract.Lease.Worker,
+            contract.Lease.Worker.TilePoint,
+            item,
+            new HashSet<Point>(),
+            new HashSet<HarvestChestRouteKey>()) is not null;
     }
 
     private void CaptureHarvestItem(ActiveHarvestContract contract, Item item, string source)

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -82,6 +82,7 @@ List<(string Name, Action Test)> tests = new()
     ("ready tapper target semantics", TestReadyTapperTargetSemantics),
     ("ready fruit-tree target semantics", TestReadyFruitTreeTargetSemantics),
     ("ready machine target semantics", TestReadyMachineTargetSemantics),
+    ("ready crab-pot target semantics", TestReadyCrabPotTargetSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
     ("harvest transfer replay protection", TestHarvestTransferReplayProtection),
     ("harvest placement conservation", TestHarvestPlacementConservation),
@@ -1894,6 +1895,22 @@ static void TestReadyMachineTargetSemantics()
         true, true, true, true, true, true, false, false, true, false));
     Equal(false, MachineHarvestSemantics.IsReadyTarget(
         true, true, true, true, true, true, false, false, false, true));
+}
+
+static void TestReadyCrabPotTargetSemantics()
+{
+    Equal(true, CrabPotHarvestSemantics.IsReadyTarget(true, true, true));
+    Equal(false, CrabPotHarvestSemantics.IsReadyTarget(false, true, true));
+    Equal(false, CrabPotHarvestSemantics.IsReadyTarget(true, false, true));
+    Equal(false, CrabPotHarvestSemantics.IsReadyTarget(true, true, false));
+    Equal(2, CrabPotHarvestSemantics.GetOutputStack(1, true, 0.10, true));
+    Equal(1, CrabPotHarvestSemantics.GetOutputStack(1, false, 0.10, true));
+    Equal(1, CrabPotHarvestSemantics.GetOutputStack(1, true, 0.25, true));
+    Equal(1, CrabPotHarvestSemantics.GetOutputStack(1, true, 0.10, false));
+    Throws<ArgumentOutOfRangeException>(() =>
+        CrabPotHarvestSemantics.GetOutputStack(0, true, 0.10, true));
+    Throws<ArgumentOutOfRangeException>(() =>
+        CrabPotHarvestSemantics.GetOutputStack(1, true, 1, true));
 }
 
 static void TestHarvestPlacementConservation()


### PR DESCRIPTION
## Summary

- add ready crab pots to complete-shift target planning
- preserve the vanilla deterministic Crabbing Book double-catch rule with destination-capacity preflight
- apply caught-fish records, random fish length, five fishing XP, bait consumption, lid/readiness reset, and removal guard
- route the exact output through the existing lossless destination pipeline without automatic rebaiting

## Linked Issue

Part of #85

## Validation

- [x] `dotnet build -c Release` (0 warnings, 0 errors)
- [x] deterministic logic tests (98/98 passed)
- [x] `git diff --check`
- [x] multiplayer impact considered: mutation remains host-owned
- [ ] SMAPI/save test deferred by maintainer request

## Notes

This focused PR does not close #85. Fish ponds, bushes, and other dedicated sources remain. No game process was launched.