### PR TITLE
feat(harvest): collect fish pond outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added fish-pond output collection through the pond bucket edge with exact item metadata and vanilla value-based fishing experience, without feeding fish or completing requests.
 - Added lossless crab-pot collection with the original deterministic Crabbing Book bonus, fish records, fishing experience, bait/readiness reset, and no automatic rebaiting.
 - Added conservative collection for simple ready vanilla machines, preserving exact output, harvest stats, experience, sprite/reset state, and lossless destinations while excluding collect-time recalculation and continuation machines.
 - Added lossless collection of eggs and other resident-animal loose products plus tool-ready milk and wool, with exact vanilla produce state, locked deterministic destinations, rollback on failed commits, and auto-grabber exclusion.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - 收获所有能够安全到达的成熟作物，以及树上已经就绪的普通或重型树液采集器产物；
 - 收取能够安全完成原版状态重置的普通生产机器成品；
 - 收取已就绪蟹笼的产物并保留原版收集加成，但不会自动补饵；
+- 收取鱼塘已经生成的产物，但不会投鱼或代交鱼塘任务物品；
 - 进入畜棚和鸡舍，抚摸动物、用自有干草补满食槽，并收集鸡蛋、牛奶和羊毛；
 - 按箱子里已有的物品整理普通箱子；
 - 设置每天自动尝试执行的完整农活班次。
@@ -156,6 +157,7 @@ Each hire automatically works through these stages in order:
 - harvest every safely reachable mature crop and every ready normal or heavy tree tapper;
 - collect outputs from simple ready vanilla machines whose collection state can be preserved safely;
 - collect ready crab pots with vanilla catch bonuses and records, without automatic rebaiting;
+- collect ready fish-pond output without adding fish or completing pond requests;
 - enter barns and coops to pet animals, fill troughs from owned silo hay, and collect eggs, milk, and wool;
 - organize ordinary farm chests based on their existing contents;
 - set up a daily automatic complete farm-work shift.

--- a/docs/HARVEST_SOURCE_MATRIX.md
+++ b/docs/HARVEST_SOURCE_MATRIX.md
@@ -11,13 +11,13 @@ This matrix prevents the complete shift from treating every object with a held i
 | Fruit trees | Clear the tree's fruit list once after capturing every non-null fruit slot | Stored item, stack, and quality are preserved. Lightning-struck trees produce one coal per occupied fruit slot like vanilla. |
 | Simple ready vanilla machines | Clear the held output and ready/display state, reset the sprite, apply declared harvest stats and experience, and never auto-load another input | Limited to exact vanilla `Object` machines with numeric IDs and no collect-time recalculation or `OutputCollected` continuation rule. Exact output metadata enters the existing lossless destination pipeline. |
 | Crab pots | Preserve the deterministic Crabbing Book double-catch rule, caught-fish record/length, five fishing XP, consumed bait, lid/readiness state, and short removal guard | Collect the existing exact output through the lossless destination pipeline. Never refill bait automatically. |
+| Fish ponds | Clear only the ready building-owned output and grant vanilla fishing experience: 10 plus 4% of the object's store value | Route to the pond's item-bucket edge, preserve the exact output, and never add fish or satisfy pond requests. |
 
 ## Requires a dedicated implementation
 
 | Source | Why generic `heldObject` removal is unsafe |
 | --- | --- |
 | Stateful data-driven machines | Machines with collect-time recalculation or `OutputCollected` continuation rules can replace output, consume retained input, or immediately start another cycle. They remain excluded until that continuation can be rolled back exactly. |
-| Fish ponds | Collection clears the building output and grants fishing experience based on value. The interaction tile and building-owned output need a building-target route. |
 | Berry and tea bushes | Output count, quality, experience, mutex behavior, and special walnut bushes depend on bush type and the requesting farmer. Special/map bushes must be excluded explicitly. |
 | Farm-building interiors | Barns, coops, sheds, caves, and greenhouse-like locations need location-aware entrances, doors, route ownership, and return behavior before their contents can join a main-farm shift. |
 | Loose forage and spawned objects | Ownership, quest/special items, spawned-object flags, and terrain coverage need an allowlist. Debris clearing is not harvest collection. |

--- a/src/ContractHarvestCollector.cs
+++ b/src/ContractHarvestCollector.cs
@@ -119,3 +119,21 @@ internal static class CrabPotHarvestSemantics
                 : baseStack;
     }
 }
+
+internal static class FishPondHarvestSemantics
+{
+    public static bool IsReadyTarget(
+        bool constructionComplete,
+        bool upgradeComplete,
+        bool hasOutput)
+    {
+        return constructionComplete && upgradeComplete && hasOutput;
+    }
+
+    public static int GetFishingExperience(int? storeSellPrice)
+    {
+        return 10 + (storeSellPrice.HasValue
+            ? (int)(storeSellPrice.Value * 0.04f)
+            : 0);
+    }
+}

--- a/src/HarvestTargetPlanner.cs
+++ b/src/HarvestTargetPlanner.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewValley;
+using StardewValley.Buildings;
 using StardewValley.GameData.Machines;
 using StardewValley.Locations;
 using StardewValley.Objects;
@@ -23,7 +24,8 @@ internal enum HarvestTargetKind
     Tapper,
     FruitTree,
     Machine,
-    CrabPot
+    CrabPot,
+    FishPond
 }
 
 internal sealed record HarvestTargetPlan(
@@ -304,6 +306,21 @@ internal sealed class HarvestTargetPlanner
                 pot.heldObject.Value is not null);
     }
 
+    public static bool IsReadySupportedFishPond(GameLocation location, Vector2 tile)
+    {
+        if (location is not Farm farm)
+            return false;
+
+        Point point = new((int)tile.X, (int)tile.Y);
+        FishPond? pond = farm.buildings.OfType<FishPond>()
+            .FirstOrDefault(candidate => candidate.GetItemBucketTile().ToPoint() == point);
+        return pond is not null
+            && FishPondHarvestSemantics.IsReadyTarget(
+                pond.daysOfConstructionLeft.Value <= 0,
+                pond.daysUntilUpgrade.Value <= 0,
+                pond.output.Value is not null);
+    }
+
     public static HarvestTargetKind? GetSupportedTargetKind(GameLocation location, Vector2 tile)
     {
         if (IsMatureSupportedCrop(location, tile))
@@ -314,6 +331,8 @@ internal sealed class HarvestTargetPlanner
             return HarvestTargetKind.FruitTree;
         if (IsReadySupportedCrabPot(location, tile))
             return HarvestTargetKind.CrabPot;
+        if (IsReadySupportedFishPond(location, tile))
+            return HarvestTargetKind.FishPond;
         if (IsReadySupportedMachine(location, tile))
             return HarvestTargetKind.Machine;
         return null;

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Xml;
 using System.Xml.Serialization;
 using StardewValley;
+using StardewValley.Buildings;
 using StardewValley.GameData.Machines;
 using StardewValley.Inventories;
 using StardewValley.ItemTypeDefinitions;
@@ -898,6 +899,7 @@ internal sealed class HarvestingContractExecutionController
             HarvestTargetKind.FruitTree => this.TryApplyFruitTreeHarvest(contract),
             HarvestTargetKind.Machine => this.TryApplyMachineHarvest(contract),
             HarvestTargetKind.CrabPot => this.TryApplyCrabPotHarvest(contract),
+            HarvestTargetKind.FishPond => this.TryApplyFishPondHarvest(contract),
             _ => false
         };
     }
@@ -1138,6 +1140,35 @@ internal sealed class HarvestingContractExecutionController
             item,
             new HashSet<Point>(),
             new HashSet<HarvestChestRouteKey>()) is not null;
+    }
+
+    private bool TryApplyFishPondHarvest(ActiveHarvestContract contract)
+    {
+        Point target = contract.CurrentTarget.TargetTile;
+        FishPond? pond = contract.Farm.buildings.OfType<FishPond>()
+            .FirstOrDefault(candidate => candidate.GetItemBucketTile().ToPoint() == target);
+        if (pond is null
+            || !FishPondHarvestSemantics.IsReadyTarget(
+                pond.daysOfConstructionLeft.Value <= 0,
+                pond.daysUntilUpgrade.Value <= 0,
+                pond.output.Value is not null)
+            || pond.output.Value is not { } output)
+            return false;
+
+        Item collected = output.getOne();
+        collected.Stack = output.Stack;
+        collected.Quality = output.Quality;
+        int? price = collected is StardewValley.Object obj
+            ? obj.sellToStorePrice(-1L)
+            : null;
+        int experience = FishPondHarvestSemantics.GetFishingExperience(price);
+
+        pond.output.Value = null;
+        contract.Requester.gainExperience(1, experience);
+        contract.Farm.playSound("coin", target.ToVector2());
+        this.CaptureHarvestItem(contract, collected, "fish pond");
+        this.ShowHarvestedItem(contract, collected);
+        return true;
     }
 
     private void CaptureHarvestItem(ActiveHarvestContract contract, Item item, string source)

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -83,6 +83,7 @@ List<(string Name, Action Test)> tests = new()
     ("ready fruit-tree target semantics", TestReadyFruitTreeTargetSemantics),
     ("ready machine target semantics", TestReadyMachineTargetSemantics),
     ("ready crab-pot target semantics", TestReadyCrabPotTargetSemantics),
+    ("ready fish-pond target semantics", TestReadyFishPondTargetSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
     ("harvest transfer replay protection", TestHarvestTransferReplayProtection),
     ("harvest placement conservation", TestHarvestPlacementConservation),
@@ -1911,6 +1912,17 @@ static void TestReadyCrabPotTargetSemantics()
         CrabPotHarvestSemantics.GetOutputStack(0, true, 0.10, true));
     Throws<ArgumentOutOfRangeException>(() =>
         CrabPotHarvestSemantics.GetOutputStack(1, true, 1, true));
+}
+
+static void TestReadyFishPondTargetSemantics()
+{
+    Equal(true, FishPondHarvestSemantics.IsReadyTarget(true, true, true));
+    Equal(false, FishPondHarvestSemantics.IsReadyTarget(false, true, true));
+    Equal(false, FishPondHarvestSemantics.IsReadyTarget(true, false, true));
+    Equal(false, FishPondHarvestSemantics.IsReadyTarget(true, true, false));
+    Equal(10, FishPondHarvestSemantics.GetFishingExperience(null));
+    Equal(14, FishPondHarvestSemantics.GetFishingExperience(100));
+    Equal(33, FishPondHarvestSemantics.GetFishingExperience(599));
 }
 
 static void TestHarvestPlacementConservation()


### PR DESCRIPTION
## Summary

- plan fish-pond output through each pond item-bucket edge
- capture the exact building-owned output into the existing lossless destination pipeline
- clear only the ready output and grant vanilla fishing XP (10 plus 4% of object store value)
- avoid adding fish, satisfying pond requests, or mutating pond population state

## Linked Issue

Part of #85

## Validation

- [x] Release build (0 warnings, 0 errors)
- [x] deterministic logic tests (99/99 passed)
- [x] `git diff --check`
- [x] host-owned multiplayer mutation reviewed
- [ ] SMAPI/save test deferred by maintainer request

## Notes

This focused PR does not close #85. Bush collection and the remaining explicitly classified sources follow separately. No game process was launched.