### PR TITLE
feat(harvest): collect farm berry and tea bushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added main-farm berry and tea-bush collection with vanilla foraging-level quantity, Botanist quality, and experience while excluding walnut, town, map-special, and potted bushes.
 - Added fish-pond output collection through the pond bucket edge with exact item metadata and vanilla value-based fishing experience, without feeding fish or completing requests.
 - Added lossless crab-pot collection with the original deterministic Crabbing Book bonus, fish records, fishing experience, bait/readiness reset, and no automatic rebaiting.
 - Added conservative collection for simple ready vanilla machines, preserving exact output, harvest stats, experience, sprite/reset state, and lossless destinations while excluding collect-time recalculation and continuation machines.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - 收取能够安全完成原版状态重置的普通生产机器成品；
 - 收取已就绪蟹笼的产物并保留原版收集加成，但不会自动补饵；
 - 收取鱼塘已经生成的产物，但不会投鱼或代交鱼塘任务物品；
+- 采收主农场里成熟的普通浆果丛和茶树，保留采集等级与植物学家的加成；
 - 进入畜棚和鸡舍，抚摸动物、用自有干草补满食槽，并收集鸡蛋、牛奶和羊毛；
 - 按箱子里已有的物品整理普通箱子；
 - 设置每天自动尝试执行的完整农活班次。
@@ -158,6 +159,7 @@ Each hire automatically works through these stages in order:
 - collect outputs from simple ready vanilla machines whose collection state can be preserved safely;
 - collect ready crab pots with vanilla catch bonuses and records, without automatic rebaiting;
 - collect ready fish-pond output without adding fish or completing pond requests;
+- harvest ready ordinary berry and tea bushes on the main farm with vanilla Foraging bonuses;
 - enter barns and coops to pet animals, fill troughs from owned silo hay, and collect eggs, milk, and wool;
 - organize ordinary farm chests based on their existing contents;
 - set up a daily automatic complete farm-work shift.

--- a/docs/HARVEST_SOURCE_MATRIX.md
+++ b/docs/HARVEST_SOURCE_MATRIX.md
@@ -12,13 +12,13 @@ This matrix prevents the complete shift from treating every object with a held i
 | Simple ready vanilla machines | Clear the held output and ready/display state, reset the sprite, apply declared harvest stats and experience, and never auto-load another input | Limited to exact vanilla `Object` machines with numeric IDs and no collect-time recalculation or `OutputCollected` continuation rule. Exact output metadata enters the existing lossless destination pipeline. |
 | Crab pots | Preserve the deterministic Crabbing Book double-catch rule, caught-fish record/length, five fishing XP, consumed bait, lid/readiness state, and short removal guard | Collect the existing exact output through the lossless destination pipeline. Never refill bait automatically. |
 | Fish ponds | Clear only the ready building-owned output and grant vanilla fishing experience: 10 plus 4% of the object's store value | Route to the pond's item-bucket edge, preserve the exact output, and never add fish or satisfy pond requests. |
+| Main-farm berry and tea bushes | Clear the ready sprite state; berry count follows foraging level, Botanist quality is preserved, berry XP matches count, and tea yields one leaf without XP | Only ordinary medium berry bushes and mature tea bushes in the main farm location are eligible. Walnut, town/cosmetic, map-special, and potted bushes are excluded. |
 
 ## Requires a dedicated implementation
 
 | Source | Why generic `heldObject` removal is unsafe |
 | --- | --- |
 | Stateful data-driven machines | Machines with collect-time recalculation or `OutputCollected` continuation rules can replace output, consume retained input, or immediately start another cycle. They remain excluded until that continuation can be rolled back exactly. |
-| Berry and tea bushes | Output count, quality, experience, mutex behavior, and special walnut bushes depend on bush type and the requesting farmer. Special/map bushes must be excluded explicitly. |
 | Farm-building interiors | Barns, coops, sheds, caves, and greenhouse-like locations need location-aware entrances, doors, route ownership, and return behavior before their contents can join a main-farm shift. |
 | Loose forage and spawned objects | Ownership, quest/special items, spawned-object flags, and terrain coverage need an allowlist. Debris clearing is not harvest collection. |
 

--- a/src/ContractHarvestCollector.cs
+++ b/src/ContractHarvestCollector.cs
@@ -137,3 +137,50 @@ internal static class FishPondHarvestSemantics
             : 0);
     }
 }
+
+internal sealed record BushHarvestPlan(
+    string QualifiedItemId,
+    int Stack,
+    int Quality,
+    int ForagingExperience);
+
+internal static class BushHarvestSemantics
+{
+    public static bool IsReadyTarget(
+        bool isMainFarm,
+        bool isTownBush,
+        int size,
+        bool readyForHarvest,
+        bool inBloom,
+        bool hasOutput)
+    {
+        return isMainFarm
+            && !isTownBush
+            && size is 1 or 3
+            && readyForHarvest
+            && inBloom
+            && hasOutput;
+    }
+
+    public static BushHarvestPlan CreatePlan(
+        int size,
+        string qualifiedItemId,
+        int foragingLevel,
+        bool hasBotanistProfession)
+    {
+        if (size is not (1 or 3))
+            throw new ArgumentOutOfRangeException(nameof(size));
+        if (string.IsNullOrWhiteSpace(qualifiedItemId))
+            throw new ArgumentException("Bush output is required.", nameof(qualifiedItemId));
+        if (foragingLevel < 0)
+            throw new ArgumentOutOfRangeException(nameof(foragingLevel));
+
+        bool isTea = size == 3;
+        int stack = isTea ? 1 : 1 + foragingLevel / 4;
+        return new BushHarvestPlan(
+            qualifiedItemId,
+            stack,
+            !isTea && hasBotanistProfession ? 4 : 0,
+            isTea ? 0 : stack);
+    }
+}

--- a/src/HarvestTargetPlanner.cs
+++ b/src/HarvestTargetPlanner.cs
@@ -25,7 +25,8 @@ internal enum HarvestTargetKind
     FruitTree,
     Machine,
     CrabPot,
-    FishPond
+    FishPond,
+    Bush
 }
 
 internal sealed record HarvestTargetPlan(
@@ -321,6 +322,20 @@ internal sealed class HarvestTargetPlanner
                 pond.output.Value is not null);
     }
 
+    public static bool IsReadySupportedBush(GameLocation location, Vector2 tile)
+    {
+        Bush? bush = location.largeTerrainFeatures.OfType<Bush>()
+            .FirstOrDefault(candidate => candidate.Tile == tile);
+        return bush is not null
+            && BushHarvestSemantics.IsReadyTarget(
+                location is Farm,
+                bush.townBush.Value,
+                bush.size.Value,
+                bush.readyForHarvest(),
+                bush.inBloom(),
+                bush.GetShakeOffItem() is not null);
+    }
+
     public static HarvestTargetKind? GetSupportedTargetKind(GameLocation location, Vector2 tile)
     {
         if (IsMatureSupportedCrop(location, tile))
@@ -333,6 +348,8 @@ internal sealed class HarvestTargetPlanner
             return HarvestTargetKind.CrabPot;
         if (IsReadySupportedFishPond(location, tile))
             return HarvestTargetKind.FishPond;
+        if (IsReadySupportedBush(location, tile))
+            return HarvestTargetKind.Bush;
         if (IsReadySupportedMachine(location, tile))
             return HarvestTargetKind.Machine;
         return null;

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -900,6 +900,7 @@ internal sealed class HarvestingContractExecutionController
             HarvestTargetKind.Machine => this.TryApplyMachineHarvest(contract),
             HarvestTargetKind.CrabPot => this.TryApplyCrabPotHarvest(contract),
             HarvestTargetKind.FishPond => this.TryApplyFishPondHarvest(contract),
+            HarvestTargetKind.Bush => this.TryApplyBushHarvest(contract),
             _ => false
         };
     }
@@ -1167,6 +1168,45 @@ internal sealed class HarvestingContractExecutionController
         contract.Requester.gainExperience(1, experience);
         contract.Farm.playSound("coin", target.ToVector2());
         this.CaptureHarvestItem(contract, collected, "fish pond");
+        this.ShowHarvestedItem(contract, collected);
+        return true;
+    }
+
+    private bool TryApplyBushHarvest(ActiveHarvestContract contract)
+    {
+        Vector2 target = contract.CurrentTarget.TargetTile.ToVector2();
+        Bush? bush = contract.Farm.largeTerrainFeatures.OfType<Bush>()
+            .FirstOrDefault(candidate => candidate.Tile == target);
+        if (bush is null
+            || !BushHarvestSemantics.IsReadyTarget(
+                true,
+                bush.townBush.Value,
+                bush.size.Value,
+                bush.readyForHarvest(),
+                bush.inBloom(),
+                bush.GetShakeOffItem() is not null)
+            || bush.GetShakeOffItem() is not { } outputId)
+            return false;
+
+        BushHarvestPlan plan = BushHarvestSemantics.CreatePlan(
+            bush.size.Value,
+            outputId,
+            contract.Requester.ForagingLevel,
+            contract.Requester.professions.Contains(16));
+        Item collected = ItemRegistry.Create(plan.QualifiedItemId);
+        collected.Stack = plan.Stack;
+        collected.Quality = plan.Quality;
+
+        bush.tileSheetOffset.Value = 0;
+        bush.setUpSourceRect();
+        bush.shakeTimer = 500f;
+        if (plan.ForagingExperience > 0)
+            contract.Requester.gainExperience(2, plan.ForagingExperience);
+        contract.Farm.playSound("leafrustle", target);
+        this.CaptureHarvestItem(
+            contract,
+            collected,
+            bush.size.Value == Bush.greenTeaBush ? "tea bush" : "berry bush");
         this.ShowHarvestedItem(contract, collected);
         return true;
     }

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -84,6 +84,7 @@ List<(string Name, Action Test)> tests = new()
     ("ready machine target semantics", TestReadyMachineTargetSemantics),
     ("ready crab-pot target semantics", TestReadyCrabPotTargetSemantics),
     ("ready fish-pond target semantics", TestReadyFishPondTargetSemantics),
+    ("ready bush target semantics", TestReadyBushTargetSemantics),
     ("harvest unavailable storage stop", TestHarvestUnavailableStorageStop),
     ("harvest transfer replay protection", TestHarvestTransferReplayProtection),
     ("harvest placement conservation", TestHarvestPlacementConservation),
@@ -1923,6 +1924,29 @@ static void TestReadyFishPondTargetSemantics()
     Equal(10, FishPondHarvestSemantics.GetFishingExperience(null));
     Equal(14, FishPondHarvestSemantics.GetFishingExperience(100));
     Equal(33, FishPondHarvestSemantics.GetFishingExperience(599));
+}
+
+static void TestReadyBushTargetSemantics()
+{
+    Equal(true, BushHarvestSemantics.IsReadyTarget(
+        true, false, 1, true, true, true));
+    Equal(true, BushHarvestSemantics.IsReadyTarget(
+        true, false, 3, true, true, true));
+    Equal(false, BushHarvestSemantics.IsReadyTarget(
+        false, false, 1, true, true, true));
+    Equal(false, BushHarvestSemantics.IsReadyTarget(
+        true, true, 1, true, true, true));
+    Equal(false, BushHarvestSemantics.IsReadyTarget(
+        true, false, 4, true, true, true));
+
+    Equal(new BushHarvestPlan("(O)296", 1, 0, 1),
+        BushHarvestSemantics.CreatePlan(1, "(O)296", 0, false));
+    Equal(new BushHarvestPlan("(O)410", 3, 4, 3),
+        BushHarvestSemantics.CreatePlan(1, "(O)410", 8, true));
+    Equal(new BushHarvestPlan("(O)815", 1, 0, 0),
+        BushHarvestSemantics.CreatePlan(3, "(O)815", 10, true));
+    Throws<ArgumentOutOfRangeException>(() =>
+        BushHarvestSemantics.CreatePlan(4, "(O)73", 10, true));
 }
 
 static void TestHarvestPlacementConservation()


### PR DESCRIPTION
## Summary

- add ready ordinary berry and tea bushes on the main farm to complete-shift planning
- preserve vanilla berry quantity from Foraging level, Botanist iridium quality, berry XP, and one-leaf/no-XP tea behavior
- clear the ready sprite state and route exact output through the existing lossless destination pipeline
- exclude walnut, town/cosmetic, map-special, and potted bushes
- finish the #85 source matrix with every reviewed source explicitly enabled, dedicated/deferred, or excluded

## Linked Issue

Closes #85

## Validation

- [x] Release build (0 warnings, 0 errors)
- [x] deterministic logic tests (100/100 passed)
- [x] `git diff --check`
- [x] host-owned multiplayer mutation reviewed
- [ ] SMAPI/save test deferred by maintainer request

## Notes

Stateful collect-time machines, arbitrary loose forage, special/map bushes, auto-grabbers, and unsafely routed non-animal interiors remain explicitly fail-closed in the source matrix; they are not silently treated as generic outputs. No game process was launched.