### PR TITLE
refactor(workforce): add deterministic route reservations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added a deterministic host-owned route reservation ledger for future concurrent workers, preventing same-tile and opposing-edge collisions with bounded waits, worker-scoped release, and immutable elapsed history; concurrent dispatch remains disabled.
 - Simplified the hiring roster and shift confirmation into compact vanilla-style summaries, added complete row-by-row controller navigation, and show warnings only when insufficient funds block confirmation.
 - Added main-farm berry and tea-bush collection with vanilla foraging-level quantity, Botanist quality, and experience while excluding walnut, town, map-special, and potted bushes.
 - Added fish-pond output collection through the pond bucket edge with exact item metadata and vanilla value-based fishing experience, without feeding fish or completing requests.

--- a/docs/MULTI_WORKER_ARCHITECTURE.md
+++ b/docs/MULTI_WORKER_ARCHITECTURE.md
@@ -23,3 +23,16 @@ The host owns this ledger. Multiplayer messages will carry shift, assignment, wo
 Each assignment will own its NPC lease, route controller, tool/cargo state, availability result, wage authorization, elapsed-time settlement, and recovery path. Storage remains protected by the existing ordered chest locks. A worker failure cannot release another worker's lock or lease.
 
 The shift report contains per-worker authorization and charge records plus a checked aggregate total. Concurrent dispatch stays disabled until runtime save/reconnect, route collision, storage lock, and settlement coverage is complete.
+
+## Route reservation gate
+
+Future concurrent movement uses a host-owned, shift-scoped route ledger before a controller receives a path:
+
+- every proposed route carries worker and assignment IDs, a requested start slot, and one tile for each movement slot;
+- simultaneous proposals are sorted by requested slot, worker ID, then assignment ID, so caller or network arrival order cannot choose a winner;
+- a tile can have only one owner in a slot, and two workers cannot traverse one edge in opposite directions in the same slot;
+- a losing proposal may shift forward only within a fixed wait budget; exhausting that budget returns a rejection instead of waiting forever;
+- the host advances one monotonic committed-through slot. Elapsed reservations remain immutable history, while worker failure releases only that worker's future tiles and edges;
+- the existing single-worker route is the one-proposal case and receives its requested start slot without delay.
+
+The deterministic ledger is implemented and covered by pure tests, but is not yet wired to live NPC controllers. Concurrent dispatch remains disabled until controller integration, save/reconnect representation, and multi-worker runtime acceptance are complete.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -99,4 +99,4 @@ Focus:
 
 ## Current Priority
 
-The current release gate is `v0.1.0`: finish real-save watering and harvest validation, complete a real host/farmhand network test, then pass the packaging and release audit. Later milestone sections describe the historical feature sequence, not permission to defer these first-release requirements.
+`v0.1.0` has been published. The current development phase prepares safe multi-worker execution one independently testable gate at a time: deterministic route reservations, assignment-based runtime state, per-worker lease and settlement isolation, storage contention, then host/reconnect coverage. Concurrent hiring remains disabled until every runtime gate passes; the existing real host/farmhand and final visual acceptance procedures remain deferred until the maintainer schedules them.

--- a/src/WorkforceRouteReservations.cs
+++ b/src/WorkforceRouteReservations.cs
@@ -1,0 +1,214 @@
+namespace EvilFarmOwner;
+
+internal readonly record struct WorkforceRouteTile(int X, int Y);
+
+internal sealed record WorkforceRouteProposal(
+    string WorkerId,
+    string AssignmentId,
+    int RequestedStartSlot,
+    IReadOnlyList<WorkforceRouteTile> Tiles);
+
+internal enum WorkforceRouteReservationFailure
+{
+    None,
+    WaitLimitExceeded
+}
+
+internal sealed record WorkforceRouteReservationResult(
+    string WorkerId,
+    string AssignmentId,
+    bool Accepted,
+    int StartSlot,
+    int WaitSlots,
+    WorkforceRouteReservationFailure Failure);
+
+internal enum WorkforceRouteReservationState
+{
+    Reserved,
+    Committed
+}
+
+internal sealed record WorkforceRouteReservationSnapshot(
+    string WorkerId,
+    string AssignmentId,
+    int Slot,
+    WorkforceRouteTile Tile,
+    WorkforceRouteReservationState State);
+
+/// <summary>Host-owned, shift-scoped tile and movement-edge reservations.</summary>
+internal sealed class DeterministicWorkforceRouteLedger
+{
+    private readonly Dictionary<TileSlot, ReservationOwner> TileOwners = new();
+    private readonly Dictionary<EdgeSlot, ReservationOwner> EdgeOwners = new();
+    private int CommittedThroughSlot = -1;
+
+    public IReadOnlyList<WorkforceRouteReservationResult> ReserveBatch(
+        IEnumerable<WorkforceRouteProposal> proposals,
+        int maximumWaitSlots)
+    {
+        ArgumentNullException.ThrowIfNull(proposals);
+        if (maximumWaitSlots < 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumWaitSlots));
+
+        WorkforceRouteProposal[] ordered = proposals
+            .Select(Validate)
+            .OrderBy(proposal => proposal.RequestedStartSlot)
+            .ThenBy(proposal => proposal.WorkerId, StringComparer.Ordinal)
+            .ThenBy(proposal => proposal.AssignmentId, StringComparer.Ordinal)
+            .ToArray();
+        if (ordered
+            .Select(proposal => (proposal.WorkerId, proposal.AssignmentId))
+            .Distinct()
+            .Count() != ordered.Length)
+        {
+            throw new ArgumentException(
+                "A route batch cannot contain the same worker assignment twice.",
+                nameof(proposals));
+        }
+
+        List<WorkforceRouteReservationResult> results = new(ordered.Length);
+        foreach (WorkforceRouteProposal proposal in ordered)
+            results.Add(this.ReserveOne(proposal, maximumWaitSlots));
+        return results;
+    }
+
+    public void AdvanceCommittedThrough(int slot)
+    {
+        if (slot < this.CommittedThroughSlot)
+            throw new ArgumentOutOfRangeException(nameof(slot), "The host route clock cannot move backwards.");
+        this.CommittedThroughSlot = slot;
+    }
+
+    public int ReleaseUncommitted(string workerId)
+    {
+        if (string.IsNullOrWhiteSpace(workerId))
+            throw new ArgumentException("Worker ID is required.", nameof(workerId));
+
+        TileSlot[] releasedTiles = this.TileOwners
+            .Where(pair => pair.Value.WorkerId == workerId && pair.Key.Slot > this.CommittedThroughSlot)
+            .Select(pair => pair.Key)
+            .ToArray();
+        foreach (TileSlot tile in releasedTiles)
+            this.TileOwners.Remove(tile);
+
+        EdgeSlot[] releasedEdges = this.EdgeOwners
+            .Where(pair => pair.Value.WorkerId == workerId && pair.Key.Slot > this.CommittedThroughSlot)
+            .Select(pair => pair.Key)
+            .ToArray();
+        foreach (EdgeSlot edge in releasedEdges)
+            this.EdgeOwners.Remove(edge);
+
+        return releasedTiles.Length;
+    }
+
+    public IReadOnlyList<WorkforceRouteReservationSnapshot> Snapshot()
+    {
+        return this.TileOwners
+            .OrderBy(pair => pair.Key.Slot)
+            .ThenBy(pair => pair.Key.Tile.X)
+            .ThenBy(pair => pair.Key.Tile.Y)
+            .ThenBy(pair => pair.Value.WorkerId, StringComparer.Ordinal)
+            .Select(pair => new WorkforceRouteReservationSnapshot(
+                pair.Value.WorkerId,
+                pair.Value.AssignmentId,
+                pair.Key.Slot,
+                pair.Key.Tile,
+                pair.Key.Slot <= this.CommittedThroughSlot
+                    ? WorkforceRouteReservationState.Committed
+                    : WorkforceRouteReservationState.Reserved))
+            .ToArray();
+    }
+
+    private WorkforceRouteReservationResult ReserveOne(
+        WorkforceRouteProposal proposal,
+        int maximumWaitSlots)
+    {
+        for (int wait = 0; wait <= maximumWaitSlots; wait++)
+        {
+            int startSlot = checked(proposal.RequestedStartSlot + wait);
+            if (!this.CanReserve(proposal, startSlot))
+                continue;
+
+            this.CommitReservation(proposal, startSlot);
+            return new(
+                proposal.WorkerId,
+                proposal.AssignmentId,
+                true,
+                startSlot,
+                wait,
+                WorkforceRouteReservationFailure.None);
+        }
+
+        return new(
+            proposal.WorkerId,
+            proposal.AssignmentId,
+            false,
+            proposal.RequestedStartSlot,
+            maximumWaitSlots,
+            WorkforceRouteReservationFailure.WaitLimitExceeded);
+    }
+
+    private bool CanReserve(WorkforceRouteProposal proposal, int startSlot)
+    {
+        for (int step = 0; step < proposal.Tiles.Count; step++)
+        {
+            int slot = checked(startSlot + step);
+            WorkforceRouteTile tile = proposal.Tiles[step];
+            if (slot <= this.CommittedThroughSlot
+                || this.TileOwners.ContainsKey(new TileSlot(slot, tile)))
+            {
+                return false;
+            }
+
+            if (step == 0)
+                continue;
+
+            WorkforceRouteTile from = proposal.Tiles[step - 1];
+            EdgeSlot opposing = new(slot, tile, from);
+            if (this.EdgeOwners.ContainsKey(opposing))
+                return false;
+        }
+        return true;
+    }
+
+    private void CommitReservation(WorkforceRouteProposal proposal, int startSlot)
+    {
+        ReservationOwner owner = new(proposal.WorkerId, proposal.AssignmentId);
+        for (int step = 0; step < proposal.Tiles.Count; step++)
+        {
+            int slot = checked(startSlot + step);
+            WorkforceRouteTile tile = proposal.Tiles[step];
+            this.TileOwners.Add(new TileSlot(slot, tile), owner);
+            if (step > 0)
+            {
+                WorkforceRouteTile from = proposal.Tiles[step - 1];
+                this.EdgeOwners.Add(new EdgeSlot(slot, from, tile), owner);
+            }
+        }
+    }
+
+    private static WorkforceRouteProposal Validate(WorkforceRouteProposal proposal)
+    {
+        ArgumentNullException.ThrowIfNull(proposal);
+        if (string.IsNullOrWhiteSpace(proposal.WorkerId)
+            || string.IsNullOrWhiteSpace(proposal.AssignmentId)
+            || proposal.RequestedStartSlot < 0
+            || proposal.Tiles is null
+            || proposal.Tiles.Count == 0)
+        {
+            throw new ArgumentException(
+                "Every route requires worker and assignment IDs, a non-negative slot, and at least one tile.",
+                nameof(proposal));
+        }
+        return proposal;
+    }
+
+    private readonly record struct TileSlot(int Slot, WorkforceRouteTile Tile);
+
+    private readonly record struct EdgeSlot(
+        int Slot,
+        WorkforceRouteTile From,
+        WorkforceRouteTile To);
+
+    private sealed record ReservationOwner(string WorkerId, string AssignmentId);
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -17,6 +17,13 @@ List<(string Name, Action Test)> tests = new()
     ("workforce claim ownership", TestWorkforceClaimOwnership),
     ("workforce final reconciliation", TestWorkforceFinalReconciliation),
     ("workforce settlement aggregation", TestWorkforceSettlementAggregation),
+    ("workforce route same-tile arbitration", TestWorkforceRouteSameTileArbitration),
+    ("workforce route opposing-edge arbitration", TestWorkforceRouteOpposingEdgeArbitration),
+    ("workforce route stable batch order", TestWorkforceRouteStableBatchOrder),
+    ("workforce route bounded wait", TestWorkforceRouteBoundedWait),
+    ("workforce route worker release", TestWorkforceRouteWorkerRelease),
+    ("workforce route committed history", TestWorkforceRouteCommittedHistory),
+    ("workforce route single-worker equivalence", TestWorkforceRouteSingleWorkerEquivalence),
     ("animal petting idempotency", TestAnimalPettingIdempotency),
     ("animal petting route ordering", TestAnimalPettingRouteOrdering),
     ("animal finite hay conservation", TestAnimalFiniteHayConservation),
@@ -370,6 +377,139 @@ static void TestWorkforceSettlementAggregation()
         new WorkerWageSettlement("Alex", 700, 600),
         new WorkerWageSettlement("Alex", 400, 300)
     }));
+}
+
+static void TestWorkforceRouteSameTileArbitration()
+{
+    DeterministicWorkforceRouteLedger ledger = new();
+    IReadOnlyList<WorkforceRouteReservationResult> results = ledger.ReserveBatch(new[]
+    {
+        Route("Leah", "shift/leah", 0, (0, 0), (1, 0)),
+        Route("Alex", "shift/alex", 0, (0, 0), (1, 0))
+    }, maximumWaitSlots: 2);
+
+    Equal("Alex", results[0].WorkerId);
+    Equal(0, results[0].WaitSlots);
+    Equal("Leah", results[1].WorkerId);
+    Equal(1, results[1].WaitSlots);
+    Equal(4, ledger.Snapshot().Count);
+}
+
+static void TestWorkforceRouteOpposingEdgeArbitration()
+{
+    DeterministicWorkforceRouteLedger ledger = new();
+    IReadOnlyList<WorkforceRouteReservationResult> results = ledger.ReserveBatch(new[]
+    {
+        Route("Alex", "shift/alex", 0, (0, 0), (1, 0)),
+        Route("Leah", "shift/leah", 0, (1, 0), (0, 0))
+    }, maximumWaitSlots: 3);
+
+    Equal(true, results.All(result => result.Accepted));
+    Equal(2, results[1].WaitSlots);
+    Equal(2, results[1].StartSlot);
+}
+
+static void TestWorkforceRouteStableBatchOrder()
+{
+    WorkforceRouteProposal[] proposals =
+    {
+        Route("Robin", "shift/robin", 3, (4, 4), (5, 4)),
+        Route("Alex", "shift/alex", 3, (4, 4), (5, 4)),
+        Route("Leah", "shift/leah", 3, (4, 4), (5, 4))
+    };
+    DeterministicWorkforceRouteLedger first = new();
+    DeterministicWorkforceRouteLedger second = new();
+    string firstResult = string.Join(",", first.ReserveBatch(proposals, 4)
+        .Select(result => $"{result.WorkerId}:{result.StartSlot}"));
+    string secondResult = string.Join(",", second.ReserveBatch(proposals.Reverse(), 4)
+        .Select(result => $"{result.WorkerId}:{result.StartSlot}"));
+
+    Equal(firstResult, secondResult);
+    Equal("Alex:3,Leah:4,Robin:5", firstResult);
+}
+
+static void TestWorkforceRouteBoundedWait()
+{
+    DeterministicWorkforceRouteLedger ledger = new();
+    IReadOnlyList<WorkforceRouteReservationResult> results = ledger.ReserveBatch(new[]
+    {
+        Route("Alex", "shift/alex", 0, (0, 0), (1, 0)),
+        Route("Leah", "shift/leah", 0, (0, 0), (1, 0))
+    }, maximumWaitSlots: 0);
+
+    Equal(true, results[0].Accepted);
+    Equal(false, results[1].Accepted);
+    Equal(WorkforceRouteReservationFailure.WaitLimitExceeded, results[1].Failure);
+    Equal(2, ledger.Snapshot().Count);
+}
+
+static void TestWorkforceRouteWorkerRelease()
+{
+    DeterministicWorkforceRouteLedger ledger = new();
+    ledger.ReserveBatch(new[]
+    {
+        Route("Alex", "shift/alex", 0, (0, 0), (1, 0), (2, 0)),
+        Route("Leah", "shift/leah", 0, (0, 1), (1, 1), (2, 1))
+    }, maximumWaitSlots: 0);
+
+    Equal(3, ledger.ReleaseUncommitted("Alex"));
+    Equal(3, ledger.Snapshot().Count);
+    Equal(true, ledger.Snapshot().All(item => item.WorkerId == "Leah"));
+    Equal(true, ledger.ReserveBatch(
+        new[] { Route("Robin", "shift/robin", 0, (0, 0), (1, 0), (2, 0)) },
+        maximumWaitSlots: 0)[0].Accepted);
+}
+
+static void TestWorkforceRouteCommittedHistory()
+{
+    DeterministicWorkforceRouteLedger ledger = new();
+    ledger.ReserveBatch(
+        new[] { Route("Alex", "shift/alex", 0, (0, 0), (1, 0), (2, 0)) },
+        maximumWaitSlots: 0);
+    ledger.AdvanceCommittedThrough(1);
+
+    Equal(1, ledger.ReleaseUncommitted("Alex"));
+    Equal(2, ledger.Snapshot().Count);
+    Equal(true, ledger.Snapshot().All(item => item.State == WorkforceRouteReservationState.Committed));
+    Equal(false, ledger.ReserveBatch(
+        new[] { Route("Leah", "shift/leah", 0, (0, 0)) },
+        maximumWaitSlots: 0)[0].Accepted);
+    Throws<ArgumentOutOfRangeException>(() => ledger.AdvanceCommittedThrough(0));
+}
+
+static void TestWorkforceRouteSingleWorkerEquivalence()
+{
+    DeterministicWorkforceRouteLedger ledger = new();
+    WorkforceRouteProposal proposal = Route(
+        "Leah",
+        "shift/leah",
+        7,
+        (2, 3),
+        (3, 3),
+        (3, 4));
+    WorkforceRouteReservationResult result = ledger.ReserveBatch(
+        new[] { proposal },
+        maximumWaitSlots: 4)[0];
+
+    Equal(true, result.Accepted);
+    Equal(7, result.StartSlot);
+    Equal(0, result.WaitSlots);
+    Equal(
+        "7:2,3|8:3,3|9:3,4",
+        string.Join("|", ledger.Snapshot().Select(item => $"{item.Slot}:{item.Tile.X},{item.Tile.Y}")));
+}
+
+static WorkforceRouteProposal Route(
+    string worker,
+    string assignment,
+    int startSlot,
+    params (int X, int Y)[] tiles)
+{
+    return new WorkforceRouteProposal(
+        worker,
+        assignment,
+        startSlot,
+        tiles.Select(tile => new WorkforceRouteTile(tile.X, tile.Y)).ToArray());
 }
 
 static void TestAnimalPettingIdempotency()


### PR DESCRIPTION
## Summary

- add a host-owned, shift-scoped tile and movement-edge reservation ledger for future workers
- arbitrate simultaneous proposals by requested slot, worker ID, and assignment ID independent of input order
- prevent same-tile occupancy and opposing edge swaps, with bounded wait attempts
- retain elapsed reservations as immutable history while releasing only a failed worker's future reservations
- document the gate and keep concurrent dispatch explicitly disabled

## Linked Issue

Closes #106

## Change Type

- [ ] `feat`: user-facing feature
- [ ] `fix`: bug fix
- [ ] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [x] `refactor`: internal code change without behavior change
- [x] `test`: test or validation work

## Validation

- [x] Built locally with `dotnet build -c Release --no-restore -p:EnableModDeploy=false -p:EnableModZip=false`
- [ ] Launched with SMAPI
- [ ] Tested in a save file
- [x] Multiplayer impact considered
- [x] Documentation updated if user-facing behavior changed

## Notes

- 107 deterministic logic tests pass.
- No live controller is wired to this ledger and concurrent hiring remains disabled.
- Per maintainer direction, no game or save-file validation was performed.