### PR TITLE
fix(contracts): continue work after requester leaves farm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Kept named workers moving and completing farm work after the requester leaves the farm; an explicitly selected requester inventory now remains available across maps while that player is online and has room for the complete stack.
 - Added a deterministic host-owned route reservation ledger for future concurrent workers, preventing same-tile and opposing-edge collisions with bounded waits, worker-scoped release, and immutable elapsed history; concurrent dispatch remains disabled.
 - Simplified the hiring roster and shift confirmation into compact vanilla-style summaries, added complete row-by-row controller navigation, and show warnings only when insufficient funds block confirmation.
 - Added main-farm berry and tea-bush collection with vanilla foraging-level quantity, Botanist quality, and experience while excluding walnut, town, map-special, and potted bushes.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 确认雇佣时可以为本班次的收获物选择：
 
 - **分类箱**：默认选项。工人会根据箱子里已经存放的内容寻找合适位置。
-- **玩家背包**：适合玩家仍在农场、并且背包有足够空间的情况。
+- **玩家背包**：只要该玩家仍在线且背包有足够空间，离开农场后也能继续接收产物。
 
 一份合同开始后不会偷偷改变目的地。若所选位置无法完整接收当前物品，工人会停止继续收获，并保护已经拿到的产物。
 
@@ -190,7 +190,7 @@ Stand on the main farm, press `K`, choose a green available worker, review the w
 
 Only one named contract can run at a time. Contracts must start by 4:00 PM and stop safely before 10:00 PM.
 
-For harvesting, classified chests are the default. You can instead choose the requester inventory when that player is on the farm and has enough room. The shipping bin is never used as a fallback.
+For harvesting, classified chests are the default. You can instead choose the requester inventory; the worker continues off-screen and can deliver while that player is online on another map, as long as the full stack fits. The shipping bin is never used as a fallback.
 
 Chest sorting only supports ordinary player-owned chests on the main farm. It groups matching items and similar categories, and stops if the complete plan is no longer safe or possible. It is the final stage of both manual and automatic shifts.
 

--- a/src/AnimalCareContractExecutionController.cs
+++ b/src/AnimalCareContractExecutionController.cs
@@ -540,7 +540,7 @@ internal sealed class AnimalCareContractExecutionController
             Farmer? requester = Game1.GetPlayer(
                 stage.Context.Requester.UniqueMultiplayerID,
                 onlyOnline: true);
-            if (requester is null || !ReferenceEquals(requester.currentLocation, stage.Farm))
+            if (requester is null)
             {
                 this.Complete(stage, false, "harvest.failure.requester-destination-unavailable");
                 return;

--- a/src/HarvestDestinationPolicy.cs
+++ b/src/HarvestDestinationPolicy.cs
@@ -34,12 +34,14 @@ internal static class HarvestDestinationPolicy
         bool requesterIsOnMainFarm,
         bool requesterCanAcceptCompleteStack)
     {
+        // The explicitly selected inventory follows its online requester across maps.
+        // Location is retained in this policy input so the off-farm case stays covered explicitly.
+        _ = requesterIsOnMainFarm;
         if (mode == HarvestDestinationMode.ClassifiedChests)
             return HarvestDestinationAction.RouteToClassifiedChest;
 
         return mode == HarvestDestinationMode.RequesterInventory
             && requesterIsOnline
-            && requesterIsOnMainFarm
             && requesterCanAcceptCompleteStack
                 ? HarvestDestinationAction.DeliverToRequester
                 : HarvestDestinationAction.StopUnavailable;

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -1322,7 +1322,7 @@ internal sealed class HarvestingContractExecutionController
         bool requesterIsOnline = requester is not null;
         bool requesterIsOnMainFarm = requesterIsOnline
             && ReferenceEquals(requester!.currentLocation, contract.Farm);
-        bool canAcceptCompleteStack = requesterIsOnMainFarm
+        bool canAcceptCompleteStack = requesterIsOnline
             && CanInventoryAcceptCompleteStack(requester!, entry.Item);
         HarvestDestinationAction action = HarvestDestinationPolicy.SelectAction(
             contract.DestinationMode,
@@ -1333,7 +1333,7 @@ internal sealed class HarvestingContractExecutionController
         {
             this.StopForUnavailableStorage(
                 contract,
-                "the contract-selected requester inventory is offline, off-farm, or cannot accept the complete stack",
+                "the contract-selected requester inventory is offline or cannot accept the complete stack",
                 "harvest.failure.requester-destination-unavailable");
             return;
         }

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -1325,11 +1325,18 @@ static void TestHarvestContractDestinationPolicy()
             requesterIsOnMainFarm: true,
             requesterCanAcceptCompleteStack: true));
     Equal(
+        HarvestDestinationAction.DeliverToRequester,
+        HarvestDestinationPolicy.SelectAction(
+            HarvestDestinationMode.RequesterInventory,
+            requesterIsOnline: true,
+            requesterIsOnMainFarm: false,
+            requesterCanAcceptCompleteStack: true));
+    Equal(
         HarvestDestinationAction.StopUnavailable,
         HarvestDestinationPolicy.SelectAction(
             HarvestDestinationMode.RequesterInventory,
             requesterIsOnline: true,
-            requesterIsOnMainFarm: true,
+            requesterIsOnMainFarm: false,
             requesterCanAcceptCompleteStack: false));
     Equal(
         HarvestDestinationAction.StopUnavailable,


### PR DESCRIPTION
## Summary

- confirm from Stardew Valley 1.6.15 runtime IL that the host updates farm NPC controllers through off-screen location updates
- remove the main-farm location gate from the explicitly selected requester-inventory delivery
- apply the same cross-map online requester rule to harvested crops and animal products
- preserve the selected destination: offline or insufficient-capacity requesters still stop safely without switching to chests
- document off-screen continuation in Chinese and English

## Linked Issue

Closes #109

## Change Type

- [ ] `feat`: user-facing feature
- [x] `fix`: bug fix
- [ ] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [x] `test`: test or validation work

## Validation

- [x] Built locally with `dotnet build -c Release --no-restore -p:EnableModDeploy=false -p:EnableModZip=false`
- [ ] Launched with SMAPI
- [ ] Tested in a save file
- [x] Multiplayer impact considered
- [x] Documentation updated if user-facing behavior changed

## Notes

- 107 deterministic logic tests pass, including an online off-farm requester case plus offline/full rejection.
- No silent fallback to classified chests was added.
- Per maintainer direction, no game or save-file validation was performed.