### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.0 - 2026-08-26
+
 - Kept named workers moving and completing farm work after the requester leaves the farm; an explicitly selected requester inventory now remains available across maps while that player is online and has room for the complete stack.
 - Added a deterministic host-owned route reservation ledger for future concurrent workers, preventing same-tile and opposing-edge collisions with bounded waits, worker-scoped release, and immutable elapsed history; concurrent dispatch remains disabled.
 - Simplified the hiring roster and shift confirmation into compact vanilla-style summaries, added complete row-by-row controller navigation, and show warnings only when insufficient funds block confirmation.
@@ -21,7 +23,7 @@
 - Upgraded the host-authoritative multiplayer protocol to version 9 and migrated valid legacy automatic watering/harvest authorizations to complete farm work without raising their saved wage caps.
 - Added object-safe collection of ready normal and heavy tree-tapper products to harvest contracts, with vanilla rescheduling and the existing lossless destination pipeline.
 
-## 0.1.0 - Unreleased
+## 0.1.0 - 2026-08-25
 
 - Made harvest delivery a contract-level choice: classified chests are the manual and automatic default, requester inventory is explicit, and a running contract never silently switches between them.
 - Isolated a crop after its live interaction routes are exhausted instead of marking every remaining crop unreachable; three independently stalled crops at one origin still trigger a bounded safe return.

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <AssemblyName>EvilFarmOwner</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Aveouter/EvilFarmOwner</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -8,229 +8,210 @@
 </h1>
 
 <p align="center">
-  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.1.0
+  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.2.0
 </p>
 
 <p align="center">
-  花钱雇佣镇民，让他们真正走进农场，帮你浇水、收获、照顾动物和整理箱子。<br>
-  Hire townspeople to walk onto your farm and help with watering, harvesting, animal care, and chest sorting.
+  雇佣有空的镇民，让他们真正走进农场完成一整班农活。<br>
+  Hire available townspeople to walk onto your farm and complete a full work shift.
 </p>
 
 <p align="center">
   <a href="https://github.com/Aveouter/EvilFarmOwner/releases/latest">下载最新版 / Download</a> ·
-  <a href="#中文说明">中文说明</a> ·
-  <a href="#english">English</a>
+  <a href="#中文">中文</a> ·
+  <a href="#english">English</a> ·
+  <a href="https://github.com/Aveouter/EvilFarmOwner/issues">问题反馈 / Issues</a>
 </p>
 
 ---
 
-## 中文说明
+## 中文
 
-### 这是一个什么 Mod？
+### 简介
 
-“邪恶农场主”让你用金币雇佣有空的成年 NPC 来做农活。
+“邪恶农场主”允许你花金币雇佣当前有空的成年 NPC。工人会从农场边界入口出现，绕开箱子、机器、栅栏和棚架作物，完成工作后返回入口。
 
-工人不会瞬间完成任务。他们会从农场入口走进来，在田地和箱子之间移动，完成工作后再离开。正在参加节日、执行剧情或忙于其他事情的 NPC 不会出现在名单中，因此不会被强行打断。
+参加节日、剧情、工作日程或其他受保护活动的 NPC 不会出现在候选名单中。Mod 不会为了雇佣而中断原版活动，也不会让儿童工作。
 
-每次雇佣会自动按顺序处理：
+### 快速开始
 
-- 浇灌所有能够安全到达的缺水作物；
-- 收获所有能够安全到达的成熟作物，以及树上已经就绪的普通或重型树液采集器产物；
-- 收取能够安全完成原版状态重置的普通生产机器成品；
-- 收取已就绪蟹笼的产物并保留原版收集加成，但不会自动补饵；
-- 收取鱼塘已经生成的产物，但不会投鱼或代交鱼塘任务物品；
-- 采收主农场里成熟的普通浆果丛和茶树，保留采集等级与植物学家的加成；
-- 进入畜棚和鸡舍，抚摸动物、用自有干草补满食槽，并收集鸡蛋、牛奶和羊毛；
-- 按箱子里已有的物品整理普通箱子；
-- 设置每天自动尝试执行的完整农活班次。
+1. 安装 [SMAPI](https://smapi.io/) 4.0 或更高版本。
+2. 从 [Releases](https://github.com/Aveouter/EvilFarmOwner/releases/latest) 下载 ZIP。
+3. 解压后，把 `EvilFarmOwner` 文件夹放进游戏的 `Mods` 文件夹。
+4. 通过 SMAPI 启动游戏，载入存档并站在主农场。
+5. 按 `K`，选择一名工人，确认工资和产物去向，然后开始班次。
 
-### 主要特点
+需要 Stardew Valley 1.6 或更高版本。Generic Mod Config Menu 是可选的，可用于修改打开名单的按键。
 
-- 按 `K` 打开工人名单，查看好感度和今日最高授权工资。
-- 工资会受到好感度影响；休息日工作需要明确同意三倍工资。
-- 工人会绕开箱子、木桶、机器、栅栏和棚架作物，不会为了赶路破坏农场摆设。
-- 遇到临时障碍时会尝试换路；个别目标无法到达时会跳过并继续其他工作。
-- 收获前可以选择把产物交给玩家，或送进农场里的分类箱。
-- 箱子分类会优先寻找已有相同物品的箱子，再参考物品种类。
-- 如果没有位置能放下完整一组物品，合同会安全停止。已经收获的物品不会静默消失，也不会自动出售。
-- 出工时最多预留六小时工资，结束后按实际开始的小时结算，并退回未使用的部分。
-- 支持中文和英文。
+### 一次雇佣会做什么？
 
-### 安装
+一份合同会按以下顺序完成所有当前可执行的工作：
 
-1. 安装 [SMAPI](https://smapi.io/)。
-2. 从 [Releases](https://github.com/Aveouter/EvilFarmOwner/releases/latest) 下载最新版 ZIP。
-3. 解压后，把里面的 `EvilFarmOwner` 文件夹放进游戏的 `Mods` 文件夹。
-4. 通过 SMAPI 启动《星露谷物语》。
+1. **收获**：成熟作物、果树果实、普通或重型树液采集器、部分可安全收取的原版机器、蟹笼、鱼塘、浆果丛和茶树。
+2. **浇水**：所有能够安全到达的缺水作物。
+3. **动物照料**：进入畜棚和鸡舍，抚摸动物、从自有筒仓取干草填食槽，并收集鸡蛋、牛奶和羊毛。
+4. **整理箱子**：根据箱子里已有的物品，把普通农场箱子中的完整物品堆叠按同物品和同类别整理。
+5. **最终复查**：再进行一次有上限的检查，处理班次途中刚刚变为可执行的工作。
 
-需要 Stardew Valley 1.6 或更高版本，以及 SMAPI 4.0 或更高版本。
+没有工作的阶段会自动跳过。个别目标无法到达时，工人会尝试换路或跳过；安全条件失效时合同会明确停止，不会破坏农场摆设。
 
-### 怎么玩
+玩家离开农场后，NPC 仍会在农场继续工作。当前同一时间只能执行一份合同、雇佣一名工人。
 
-1. 载入存档并站在主农场。
-2. 按 `K` 打开工人名单。
-3. 选择一位绿色显示、当前可以雇佣的 NPC。
-4. 查看工资、收获物目的地和完整工作范围，确认雇佣。
-5. 工人会依次收获、浇水、照顾动物、整理箱子；当前没有工作的阶段会自动跳过。
-6. 等待工人完成整个班次并返回。
+### 工资
 
-同一时间只能执行一份合同。合同最迟需要在下午 4:00 前开始，并会在晚上 10:00 前安全结束。
+- 名单会显示 NPC 的好感度和今日最高授权工资。
+- 当前基础工资为每小时 100g；好感度越高，工资越低。
+- 普通班次最多按六个已开始的小时结算。
+- 休息日需要明确授权三倍工资。
+- 开工时暂时预留最高工资，工人返回后按实际工时收费并退回剩余金币。
 
-如果名单为空，通常表示镇民此刻都在忙。稍等一段游戏时间后重新打开名单即可。
+工资与班次偏好设置正在设计中，见 [Issue #108](https://github.com/Aveouter/EvilFarmOwner/issues/108)。
 
-### 收获物会放到哪里？
+### 收获物去向
 
-确认雇佣时可以为本班次的收获物选择：
+确认雇佣时可以选择：
 
-- **分类箱**：默认选项。工人会根据箱子里已经存放的内容寻找合适位置。
-- **玩家背包**：只要该玩家仍在线且背包有足够空间，离开农场后也能继续接收产物。
+- **分类箱**（默认）：寻找主农场上的普通玩家箱子，依次优先同品质可堆叠物品、同物品、同 `Item.Category`，最后才使用容量最大的空箱。
+- **玩家背包**：只要请求合同的玩家仍在线且背包能完整放下当前物品，即使已经离开农场也能接收。
 
-一份合同开始后不会偷偷改变目的地。若所选位置无法完整接收当前物品，工人会停止继续收获，并保护已经拿到的产物。
-
-分类箱仅支持主农场上的普通玩家箱子。出售箱不会被当作备用仓库。
-
-### 箱子整理
-
-箱子整理会观察普通箱子里已经放了什么，并尽量把相同物品、相近类别的物品放在一起。
-
-开始前会先确认整个整理计划能够完成。工人只移动完整的一组物品；如果箱子内容在途中发生变化，或没有足够空间，合同会停止，而不是猜测应该把物品放到哪里。
-
-箱子整理是完整班次的最后一个阶段；没有可执行的整理计划时会自动跳过。
+一份合同开始后不会偷偷切换目的地。所选位置无法接收完整物品堆叠时，合同会安全停止；已经取得的物品会保存在背包、箱子、可见掉落或恢复存储中，不会静默消失，也不会自动出售。
 
 ### 自动合同
 
-主机可以在工人名单底部选择“自动合同”，设置一份每天使用的授权：
+主机可以从工人名单底部打开“自动合同”，设置：
 
-- 选择首选工人；
-- 决定是否允许名单中的其他成年 NPC 作为替补；
-- 设置工资预算；
-- 决定休息日是否允许三倍工资。
+- 首选工人；
+- 明确允许的替补名单；
+- 普通日工资上限；
+- 是否允许休息日三倍工资。
 
-授权从下一个游戏日开始。主机在上午 6:10 到下午 4:00 之间进入主农场时，Mod 会尝试安排一次工作。NPC、预算、作物、路线或储存条件不合适时，当天会跳过，不会强行派工。
+授权从下一个游戏日开始。主机在上午 6:10 到下午 4:00 之间进入主农场时，Mod 每天最多尝试一次。自动合同与手动雇佣执行同一套完整班次；NPC、预算、路线或储存条件不合适时会跳过当天。
 
 ### 多人游戏
 
-主机和农场工都可以提出合同请求，但实际的金币、NPC 和农场内容由主机处理。
+主机和农场工都可以申请合同，但只有主机修改金币、NPC、作物、动物和箱子。所有玩家必须安装完全相同的 Mod 版本。
 
-所有玩家必须安装完全相同版本的 Evil Farm Owner。多人功能尚未完成真实双进程的完整验收，因此建议先备份存档，并在发现问题时同时提供主机和农场工的 SMAPI 日志。
+协议包含重复请求防护、阶段同步、断线重连和主机重启后的历史结果恢复。真实双进程多人验收仍未完成，重要存档请先备份；报告联机问题时请同时提供主机与农场工的 SMAPI 日志。
 
-### 常用命令与排查
+### 常用命令
 
-大多数玩家只需要按 `K`。遇到问题时可以在 SMAPI 控制台使用：
+大多数玩家只需要按 `K`。排查问题时可在 SMAPI 控制台使用：
 
 ```text
 efo_roster       打开工人名单
-efo_report       查看最近一份合同的结果
-efo_overflow     查看因储存失败而保留的收获物
-efo_quarantine   查看应急保护的物品
-efo_auto         打开自动合同设置
+efo_auto         打开自动合同
+efo_report       查看最近一次合同结果
+efo_overflow     查看因储存失败而保留的物品
+efo_quarantine   查看需要人工取回的应急保护物品
+efo_netstatus    查看联机合同状态
 ```
 
-如果旧配置仍使用 `H`，它可能与 UI Info Suite 2 冲突。请在 Generic Mod Config Menu 中把快捷键改为 `K`，或编辑：
-
-```text
-Mods/EvilFarmOwner/config.json
-```
-
-遇到物品、合同或多人问题时，请保留 SMAPI 日志，并通过 [Issues](https://github.com/Aveouter/EvilFarmOwner/issues) 提交。
+如果旧配置使用 `H` 并与 UI Info Suite 2 冲突，请通过 Generic Mod Config Menu 改回 `K`，或编辑 `Mods/EvilFarmOwner/config.json`。
 
 ### 当前限制
 
-- 暂不支持清理杂物、播种、施肥、自动补充机器原料或自动出售；需要在收取时重新计算或自动续产的机器，以及动物自动采集器内部箱子，不会被本 Mod 接管。
-- 暂不支持特殊箱子和其他 Mod 添加的箱子。
-- 自动合同与手动雇佣执行同一套完整班次，包括当前可执行的箱子整理。
-- 个别农场布局可能没有安全路线；这种情况下合同会拒绝开始或提前停止。
-- v0.1.0 是维护者决定提前发布的首个正式版本；强制储存故障的全部场景、真实双进程多人和最终游戏内发布包测试尚未完整验证。重要存档请先备份。
+- 暂不支持清理杂物、播种、施肥、自动补充机器原料或自动出售。
+- 不接管动物自动采集器；也不收取会在交互时重新计算产物或自动续产的机器。
+- 仅支持主农场上的普通玩家箱子，不支持特殊箱子和其他 Mod 添加的箱子。
+- 当前一次只能雇佣一名工人；多人调度、路线预留和工资汇总仍在逐步接入，尚未开放并发。
+- 自定义农场如果没有安全路线，合同会拒绝开始或提前停止。
+- 强制储存故障矩阵、真实双进程多人和最终发布 ZIP 的游戏内烟雾测试尚未完整执行。
 
 ---
 
 ## English
 
-### What is Evil Farm Owner?
+### Overview
 
-Evil Farm Owner lets you pay available adult townspeople to help with farm chores.
+Evil Farm Owner lets you pay currently available adult NPCs to work a full farm shift. A worker enters through a farm-boundary entrance, routes around chests, machines, fences, and trellis crops, then returns when the shift ends.
 
-Workers do not finish jobs instantly. They enter through a farm boundary, walk between crops and chests, do the visible work, and leave when the contract ends. NPCs who are busy with festivals, events, or protected schedules are left alone and do not appear in the hiring list.
+NPCs who are busy with festivals, events, work schedules, or other protected activities are omitted from the roster. The mod never interrupts those activities and never permits child labor.
 
-Each hire automatically works through these stages in order:
+### Quick start
 
-- water every safely reachable dry crop;
-- harvest every safely reachable mature crop and every ready normal or heavy tree tapper;
-- collect outputs from simple ready vanilla machines whose collection state can be preserved safely;
-- collect ready crab pots with vanilla catch bonuses and records, without automatic rebaiting;
-- collect ready fish-pond output without adding fish or completing pond requests;
-- harvest ready ordinary berry and tea bushes on the main farm with vanilla Foraging bonuses;
-- enter barns and coops to pet animals, fill troughs from owned silo hay, and collect eggs, milk, and wool;
-- organize ordinary farm chests based on their existing contents;
-- set up a daily automatic complete farm-work shift.
-
-### Highlights
-
-- Press `K` to see available workers, friendship, and today's maximum authorization.
-- Friendship affects pay. Rest-day work requires explicit approval for triple wages.
-- Workers route around chests, machines, fences, kegs, and trellis crops without destroying placed objects.
-- Harvest output can go to classified farm chests or directly to the requesting player's inventory.
-- A running contract keeps the destination you selected. If it cannot hold the full stack, work stops safely.
-- Harvested items are never silently deleted or automatically shipped.
-- Up to six hours of wages are reserved when work starts; unused money is refunded afterward.
-- English and Chinese are included.
-
-### Install
-
-1. Install [SMAPI](https://smapi.io/).
-2. Download the latest ZIP from [Releases](https://github.com/Aveouter/EvilFarmOwner/releases/latest).
+1. Install [SMAPI](https://smapi.io/) 4.0 or later.
+2. Download the ZIP from [Releases](https://github.com/Aveouter/EvilFarmOwner/releases/latest).
 3. Extract it and place the `EvilFarmOwner` folder in your game's `Mods` folder.
-4. Launch Stardew Valley through SMAPI.
+4. Launch through SMAPI, load a save, and stand on the main farm.
+5. Press `K`, choose a worker, review the wage and delivery destination, then confirm.
 
-Requires Stardew Valley 1.6+ and SMAPI 4.0+.
+Stardew Valley 1.6 or later is required. Generic Mod Config Menu is optional and can change the roster hotkey.
 
-### Play
+### What does one hire do?
 
-Stand on the main farm, press `K`, choose a green available worker, review the wage and harvest destination, then confirm. The worker harvests, waters, cares for livestock, and sorts ordinary farm chests in that order; stages with no ready work are skipped automatically.
+A contract performs every currently ready stage in this order:
 
-Only one named contract can run at a time. Contracts must start by 4:00 PM and stop safely before 10:00 PM.
+1. **Harvest** mature crops, fruit trees, normal and heavy tappers, selected safe vanilla machines, crab pots, fish ponds, berry bushes, and tea bushes.
+2. **Water** every safely reachable dry crop.
+3. **Care for animals** by entering barns and coops, petting livestock, filling troughs from owned silo hay, and collecting eggs, milk, and wool.
+4. **Sort chests** by moving complete stacks among ordinary farm chests according to their existing items and categories.
+5. **Reconcile once** with one bounded final pass for work that became ready during the shift.
 
-For harvesting, classified chests are the default. You can instead choose the requester inventory; the worker continues off-screen and can deliver while that player is online on another map, as long as the full stack fits. The shipping bin is never used as a fallback.
+Empty stages are skipped. The worker replans or skips isolated unreachable targets and stops explicitly when safety conditions change instead of destroying placed objects.
 
-Chest sorting only supports ordinary player-owned chests on the main farm. It groups matching items and similar categories, and stops if the complete plan is no longer safe or possible. It is the final stage of both manual and automatic shifts.
+The NPC continues working on the farm when the player changes maps. Only one contract and one worker can run at a time in the current version.
+
+### Wages
+
+- The roster shows friendship and today's maximum authorization.
+- The current base wage is 100g per hour; higher friendship reduces the rate.
+- A normal shift charges at most six started hours.
+- Rest-day work requires explicit authorization for triple pay.
+- The maximum is reserved at dispatch, then unused gold is refunded after the worker returns.
+
+Player-facing wage and shift preferences are being designed in [Issue #108](https://github.com/Aveouter/EvilFarmOwner/issues/108).
+
+### Harvest delivery
+
+Choose one destination at confirmation:
+
+- **Classified chests** (default): ordinary player chests on the main farm are ranked by compatible quality stack, same item, exact `Item.Category`, then the empty chest with the most capacity.
+- **Requester inventory**: delivery continues while that player is online on any map and can accept the complete current stack.
+
+A running contract never changes destination silently. If the selected destination cannot accept the whole stack, the contract stops safely. Already owned items remain in inventory, a chest, a visible drop, or recovery storage; they are never silently deleted or automatically shipped.
 
 ### Automatic contracts
 
-The host can create one daily authorization from the bottom of the worker list. Choose a preferred worker, allowed substitutes, budget, and whether rest-day triple pay is allowed. Automatic hiring runs the same complete farm-work shift as manual hiring.
+The host can open “Automatic contract” from the bottom of the roster and choose a preferred worker, an explicit substitute pool, a regular-day wage cap, and whether rest-day triple pay is allowed.
 
-Starting the next day, the mod tries once when the host enters the farm between 6:10 AM and 4:00 PM. It skips the day if the worker, budget, crops, route, or storage is unsuitable.
+Starting the next game day, the mod tries at most once when the host enters the main farm between 6:10 AM and 4:00 PM. Automatic hiring uses the same complete shift as manual hiring and skips the day when worker, budget, route, or storage checks fail.
 
 ### Multiplayer
 
-Hosts and farmhands can request contracts, while the host applies all money, NPC, crop, and storage changes.
+Hosts and farmhands may request contracts, but only the host changes money, NPCs, crops, animals, and storage. Every player must install the exact same mod version.
 
-Every player must install the exact same Evil Farm Owner version. Real two-process multiplayer acceptance is not yet complete, so back up important saves and include both SMAPI logs when reporting a multiplayer issue.
+The protocol includes duplicate-request protection, phase synchronization, reconnect handling, and prior-result recovery after a host restart. Real two-process acceptance is still incomplete, so back up important saves and include both host and farmhand SMAPI logs in multiplayer reports.
 
 ### Useful commands
 
+Most players only need `K`. For troubleshooting, the SMAPI console provides:
+
 ```text
 efo_roster
+efo_auto
 efo_report
 efo_overflow
 efo_quarantine
-efo_auto
+efo_netstatus
 ```
 
-Most players only need the `K` key. The extra commands help inspect recent work or recover items protected after a storage problem.
+If an old `H` hotkey conflicts with UI Info Suite 2, change it to `K` through Generic Mod Config Menu or edit `Mods/EvilFarmOwner/config.json`.
 
 ### Current limitations
 
-- No debris clearing, planting, fertilizing, automatic machine refilling, or automatic shipping. Machines which recalculate or restart on collection and auto-grabber contents are deliberately excluded.
-- No special or modded chest support.
-- Automatic contracts use the same harvest, watering, and chest-sorting sequence as manual hiring.
-- Some farm layouts may not provide a safe route; the contract will refuse or stop instead of breaking objects.
-- v0.1.0 was released early by maintainer decision. The full forced-storage matrix, real two-process multiplayer, and final in-game published-package smoke test remain incomplete. Back up important saves.
+- No debris clearing, planting, fertilizing, automatic machine refilling, or automatic shipping.
+- Auto-grabbers and machines which recalculate or automatically restart on collection are excluded.
+- Only ordinary player-owned main-farm chests are supported; special and modded chests are excluded.
+- Only one worker can be hired at a time. Multi-worker scheduling, route reservations, and aggregate billing are being integrated but concurrent dispatch is not enabled.
+- A custom farm without a safe route may reject or stop a contract.
+- The forced-storage fault matrix, real two-process multiplayer, and final in-game smoke test of the published ZIP are not yet complete.
 
 ## Compatibility
 
 - Stardew Valley 1.6+
 - SMAPI 4.0+
-- No required content packs.
+- No required content packs
+- Optional: Generic Mod Config Menu
 
 ## License
 

--- a/docs/RELEASE_NOTES_0.2.0.md
+++ b/docs/RELEASE_NOTES_0.2.0.md
@@ -1,0 +1,56 @@
+# Evil Farm Owner v0.2.0
+
+## 中文
+
+v0.2.0 把单项工作合同升级为一次完整农活班次。雇佣一名当前有空的成年 NPC 后，工人会按顺序收获、浇水、照料动物、整理普通农场箱子，并进行一次有上限的最终复查。
+
+### 主要更新
+
+- 重做简洁的原版风格雇佣名单和确认界面，只显示工人、好感度、今日最高工资、工作摘要和产物去向，并补齐手柄焦点顺序。
+- 新增果树、普通与重型树液采集器、安全的原版机器、蟹笼、鱼塘、浆果丛和茶树收取。
+- 新增畜棚与鸡舍进出、抚摸动物、从自有筒仓取干草喂食，以及鸡蛋、牛奶和羊毛收集。
+- 玩家离开农场后 NPC 仍会继续工作；选择玩家背包时，只要请求者仍在线且能放下完整堆叠即可跨地图接收。
+- 完整班次结束前进行一次有上限的最终复查，减少班次途中刚成熟或刚变为可执行的目标遗漏。
+- 自动合同现在执行与手动雇佣相同的完整班次。
+- 为未来多人雇佣加入确定性的目标声明、工作分配、工资汇总和路线时隙预留；当前仍只开放一名工人。
+
+### 安全规则
+
+- 不会为了寻路破坏农场摆设。
+- 已取得的物品不会静默消失、复制或自动出售。
+- 所选产物目的地在合同执行中不会悄悄改变。
+- 储存、路线或 NPC 状态不再安全时，合同会明确停止并保护已取得物品。
+
+## English
+
+v0.2.0 upgrades isolated jobs into one complete farm-work shift. After hiring a currently available adult NPC, the worker harvests, waters, cares for animals, sorts ordinary farm chests, and performs one bounded final reconciliation pass.
+
+### Highlights
+
+- Reworked the roster and confirmation into concise vanilla-style menus showing only worker, friendship, today's maximum wage, shift summary, and delivery destination, with complete controller focus order.
+- Added collection from fruit trees, normal and heavy tappers, selected safe vanilla machines, crab pots, fish ponds, berry bushes, and tea bushes.
+- Added barn and coop entry, animal petting, finite silo-hay feeding, and collection of eggs, milk, and wool.
+- Workers continue after the requester changes maps. A selected requester inventory remains available while that player is online and can accept the complete stack.
+- Added one bounded final reconciliation pass so work which becomes ready during the shift is checked once before settlement.
+- Automatic contracts now run the same complete shift as manual hiring.
+- Added deterministic target claims, assignment, wage aggregation, and route-slot reservations for future multi-worker hiring; current gameplay remains limited to one worker.
+
+### Safety rules
+
+- Workers do not destroy placed farm objects to make a route.
+- Owned items are never silently deleted, duplicated, or automatically shipped.
+- A running contract never changes its selected delivery destination silently.
+- Unsafe storage, routes, or NPC state stop the contract explicitly while preserving owned cargo.
+
+## Requirements / 运行要求
+
+- Stardew Valley 1.6+
+- SMAPI 4.0+
+- Exact same Evil Farm Owner version on every multiplayer peer
+- MIT License
+
+## Deferred manual acceptance / 延期人工验收
+
+The deterministic suite, clean Release build, package allowlist, manifest, license, translation parity, production-DLL scan, and public download checksum are automated release gates. The forced-storage fault matrix, real two-process multiplayer test, final visual review, and exact published-ZIP in-game smoke test remain unperformed unless separately scheduled by the maintainer.
+
+确定性测试、干净 Release 构建、包内容白名单、清单、许可证、翻译键一致性、生产 DLL 扫描及公开下载哈希属于自动发布门禁。强制储存故障矩阵、真实双进程多人、最终视觉检查和精确发布 ZIP 的游戏内烟雾测试仍需维护者另行安排，未执行的项目不会被声明为通过。

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "Name": "Evil Farm Owner",
   "Author": "Aveouter",
-  "Version": "0.1.0",
-  "Description": "Hire named adult NPCs for visible watering, lossless harvest, and deterministic chest sorting.",
+  "Version": "0.2.0",
+  "Description": "Hire available adult NPCs for complete visible farm-work shifts with safe harvest delivery.",
   "UniqueID": "Aveouter.EvilFarmOwner",
   "EntryDll": "EvilFarmOwner.dll",
   "MinimumApiVersion": "4.0.0",


### PR DESCRIPTION
## Summary

- reorganize the bilingual README around user installation, complete shifts, safety rules, and current limitations
- bump the project and manifest to v0.2.0
- add the v0.2.0 changelog and bilingual release notes

## Validation

- `bash scripts/verify-release.sh`
- 107/107 deterministic logic tests passed
- Release build: 0 warnings, 0 errors
- package allowlist, manifest, license, translation parity, and production-DLL scan passed

## Deferred manual acceptance

No game was launched. The exact published ZIP in-game smoke test, final visual review, forced-storage fault matrix, and real two-process multiplayer test remain deferred.

Tracks #111.