### PR TITLE
perf(harvest): batch cargo before storage trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Batched classified-chest harvest cargo behind a 12-stack delivery threshold, eliminating a full storage round trip after every crop, tapper, tree, machine, pot, pond, or bush while retaining the existing lossless transfer pipeline.
 - Added host-authoritative wage and complete-shift preferences through Generic Mod Config Menu: base hourly wage, friendship impact, rest-day multiplier, default harvest destination, and per-stage enablement with immutable contract snapshots and multiplayer synchronization.
 
 ## 0.2.0 - 2026-08-26

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@
 
 没有工作的阶段会自动跳过。个别目标无法到达时，工人会尝试换路或跳过；安全条件失效时合同会明确停止，不会破坏农场摆设。
 
+使用分类箱时，NPC 会连续收集产物，达到 12 个独立堆叠的送货阈值后再集中前往箱子；目标已经采完或接近停止采集时间时也会立即送货。玩家背包模式仍即时交付，因为它不需要 NPC 往返。
+
 玩家离开农场后，NPC 仍会在农场继续工作。当前同一时间只能执行一份合同、雇佣一名工人。
 
 ### 工资
@@ -148,6 +150,8 @@ A contract performs every currently ready stage in this order:
 5. **Reconcile once** with one bounded final pass for work that became ready during the shift.
 
 Empty stages are skipped. The worker replans or skips isolated unreachable targets and stops explicitly when safety conditions change instead of destroying placed objects.
+
+With classified chests selected, the NPC keeps collecting until reaching a 12-stack delivery threshold, then makes a consolidated storage run. Cargo is also delivered when no target remains or the acquisition cutoff is reached. Requester-inventory delivery remains immediate because it requires no NPC round trip.
 
 The NPC continues working on the farm when the player changes maps. Only one contract and one worker can run at a time in the current version.
 

--- a/src/HarvestCargoBatchPolicy.cs
+++ b/src/HarvestCargoBatchPolicy.cs
@@ -1,0 +1,17 @@
+namespace EvilFarmOwner;
+
+internal static class HarvestCargoBatchPolicy
+{
+    public const int DeliveryStackThreshold = 12;
+
+    public static bool ShouldDeliver(
+        int carriedStacks,
+        bool acquisitionClosed,
+        bool noRemainingTarget)
+    {
+        return carriedStacks > 0
+            && (carriedStacks >= DeliveryStackThreshold
+                || acquisitionClosed
+                || noRemainingTarget);
+    }
+}

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -369,7 +369,7 @@ internal sealed class HarvestingContractExecutionController
                 if (contract.PhaseTicks >= contract.ActionDurationTicks)
                 {
                     contract.Lease.Worker.Sprite?.ClearAnimation();
-                    this.BeginDeliveryOrReturn(contract);
+                    this.ContinueHarvestOrDeliver(contract);
                 }
                 break;
 
@@ -660,7 +660,7 @@ internal sealed class HarvestingContractExecutionController
                 + $"trying another safe interaction edge "
                 + $"[{decision.RouteFailureCount}/{decision.MaximumRouteFailures}].",
                 LogLevel.Debug);
-            this.BeginNextOrReturn(contract);
+            this.ContinueHarvestOrDeliver(contract);
             return;
         }
 
@@ -674,7 +674,7 @@ internal sealed class HarvestingContractExecutionController
                 + $"from {origin}; skipping only that crop and continuing "
                 + $"[{decision.StalledTargetCount}/{decision.MaximumStalledTargets} stalled crops at this origin].",
                 LogLevel.Warn);
-            this.BeginNextOrReturn(contract);
+            this.ContinueHarvestOrDeliver(contract);
             return;
         }
 
@@ -687,7 +687,10 @@ internal sealed class HarvestingContractExecutionController
             + $"{decision.MaximumStalledTargets} stalled harvest targets from {origin}; "
             + $"returning with {remaining} harvest target(s) marked unreachable.",
             LogLevel.Warn);
-        this.BeginReturn(contract, depositOverflowOnReturn: false);
+        if (contract.Cargo.Count > 0)
+            this.BeginDeliveryOrReturn(contract);
+        else
+            this.BeginReturn(contract, depositOverflowOnReturn: false);
     }
 
     private void HandleFailedDeliveryRoute(ActiveHarvestContract contract, string reason)
@@ -1554,7 +1557,29 @@ internal sealed class HarvestingContractExecutionController
         this.BeginDeliveryOrReturn(contract);
     }
 
-    private void BeginNextOrReturn(ActiveHarvestContract contract)
+    private void ContinueHarvestOrDeliver(ActiveHarvestContract contract)
+    {
+        if (!ReferenceEquals(this.ActiveContract, contract))
+            return;
+
+        bool deliverImmediately = contract.DestinationMode ==
+            HarvestDestinationMode.RequesterInventory;
+        bool acquisitionClosed = Game1.timeOfDay >= StopAcquiringTime;
+        if (deliverImmediately || HarvestCargoBatchPolicy.ShouldDeliver(
+                contract.Cargo.Count,
+                acquisitionClosed,
+                noRemainingTarget: false))
+        {
+            this.BeginDeliveryOrReturn(contract);
+            return;
+        }
+
+        this.BeginNextOrReturn(contract, allowHarvestWithCargo: true);
+    }
+
+    private void BeginNextOrReturn(
+        ActiveHarvestContract contract,
+        bool allowHarvestWithCargo = false)
     {
         if (!ReferenceEquals(this.ActiveContract, contract))
             return;
@@ -1568,7 +1593,7 @@ internal sealed class HarvestingContractExecutionController
             return;
         }
 
-        if (contract.Cargo.Count > 0)
+        if (contract.Cargo.Count > 0 && !allowHarvestWithCargo)
         {
             this.BeginDeliveryOrReturn(contract);
             return;
@@ -1579,7 +1604,10 @@ internal sealed class HarvestingContractExecutionController
             contract.RemainingTargets = HarvestTargetPlanner.CountRemainingHarvestTargets(
                 contract.Farm,
                 contract.CompletedTargets);
-            this.BeginReturn(contract, depositOverflowOnReturn: false);
+            if (contract.Cargo.Count > 0)
+                this.BeginDeliveryOrReturn(contract);
+            else
+                this.BeginReturn(contract, depositOverflowOnReturn: false);
             return;
         }
 
@@ -1602,7 +1630,13 @@ internal sealed class HarvestingContractExecutionController
                     + "Remaining targets are isolated by live collision, raised-seed trellises, placed objects, or previously failed edges.",
                     LogLevel.Warn);
             }
-            this.BeginReturn(contract, depositOverflowOnReturn: false);
+            if (HarvestCargoBatchPolicy.ShouldDeliver(
+                    contract.Cargo.Count,
+                    acquisitionClosed: false,
+                    noRemainingTarget: true))
+                this.BeginDeliveryOrReturn(contract);
+            else
+                this.BeginReturn(contract, depositOverflowOnReturn: false);
             return;
         }
 

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -89,6 +89,7 @@ List<(string Name, Action Test)> tests = new()
     ("storage sort save-boundary policy", TestStorageSortSaveBoundaryPolicy),
     ("harvest partial remainder", TestHarvestPartialRemainder),
     ("harvest chest release deferral", TestHarvestChestReleaseDeferral),
+    ("harvest cargo batch threshold", TestHarvestCargoBatchThreshold),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("ready tapper target semantics", TestReadyTapperTargetSemantics),
     ("ready fruit-tree target semantics", TestReadyFruitTreeTargetSemantics),
@@ -2056,6 +2057,30 @@ static void TestHarvestChestReleaseDeferral()
 
     Equal(0, remainingCargoStacks);
     Equal(2, deliveredStacks);
+}
+
+static void TestHarvestCargoBatchThreshold()
+{
+    Equal(false, HarvestCargoBatchPolicy.ShouldDeliver(
+        carriedStacks: 0,
+        acquisitionClosed: true,
+        noRemainingTarget: true));
+    Equal(false, HarvestCargoBatchPolicy.ShouldDeliver(
+        HarvestCargoBatchPolicy.DeliveryStackThreshold - 1,
+        acquisitionClosed: false,
+        noRemainingTarget: false));
+    Equal(true, HarvestCargoBatchPolicy.ShouldDeliver(
+        HarvestCargoBatchPolicy.DeliveryStackThreshold,
+        acquisitionClosed: false,
+        noRemainingTarget: false));
+    Equal(true, HarvestCargoBatchPolicy.ShouldDeliver(
+        carriedStacks: 1,
+        acquisitionClosed: true,
+        noRemainingTarget: false));
+    Equal(true, HarvestCargoBatchPolicy.ShouldDeliver(
+        carriedStacks: 1,
+        acquisitionClosed: false,
+        noRemainingTarget: true));
 }
 
 static void TestRegrowingHarvestCaptureSemantics()


### PR DESCRIPTION
## Summary

- keep collecting classified-chest harvest outputs until a 12-stack delivery threshold is reached
- flush retained cargo when the target set is exhausted or the acquisition cutoff is reached
- keep requester-inventory delivery immediate because it requires no worker round trip
- continue using independent transfer IDs and the existing chest classification, mutex, overflow, quarantine, and visible-drop guarantees for every retained stack
- let isolated target-route failures continue filling a partial batch instead of triggering an early storage run
- document the behavior and add deterministic threshold coverage

## Validation

- Release build: 0 warnings, 0 errors
- 112/112 deterministic logic tests passed
- JSON, translation parity, and `git diff --check` passed

## Manual acceptance

No game was launched. Visual movement timing and real-save throughput comparison remain deferred.

Closes #114.