### PR TITLE
fix(storage): aggregate requester inventory capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed requester-inventory preflight to count aggregate space across every compatible partial stack and usable empty slot for both harvest cargo and animal products.
 - Batched classified-chest harvest cargo behind a 12-stack delivery threshold, then grouped carried outputs by their live best destination so each chest is visited and locked once per batch while retaining independent lossless transfer identities.
 - Added host-authoritative wage and complete-shift preferences through Generic Mod Config Menu: base hourly wage, friendship impact, rest-day multiplier, default harvest destination, and per-stage enablement with immutable contract snapshots and multiplayer synchronization.
 

--- a/src/AnimalProductTransferService.cs
+++ b/src/AnimalProductTransferService.cs
@@ -156,7 +156,7 @@ internal sealed class AnimalProductTransferService
         if (!TryCreateCurrentProduct(house, target, out Item? product, out FarmAnimal? animal)
             || product is null)
             return AnimalProductTransferFailure.SourceChanged;
-        if (!CanInventoryAcceptCompleteStack(requester, product))
+        if (!RequesterInventoryCapacity.CanAcceptCompleteStack(requester, product))
             return AnimalProductTransferFailure.InsufficientCapacity;
 
         InventorySnapshot snapshot = InventorySnapshot.Capture(requester.Items);
@@ -186,27 +186,6 @@ internal sealed class AnimalProductTransferService
             snapshot.Restore(requester.Items);
             return AnimalProductTransferFailure.CommitFailed;
         }
-    }
-
-    public static bool CanInventoryAcceptCompleteStack(Farmer requester, Item item)
-    {
-        ArgumentNullException.ThrowIfNull(requester);
-        ArgumentNullException.ThrowIfNull(item);
-        if (item.IsRecipe
-            || item.QualifiedItemId is "(O)73" or "(O)930" or "(O)102" or "(O)858" or "(O)GoldCoin")
-            return true;
-
-        for (int index = 0; index < requester.MaxItems && index < requester.Items.Count; index++)
-        {
-            Item? existing = requester.Items[index];
-            if (existing is null)
-                return true;
-            if (existing.canStackWith(item)
-                && existing.Stack + item.Stack <= existing.maximumStackSize())
-                return true;
-        }
-
-        return false;
     }
 
     private static bool TryCreateCurrentProduct(

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -1132,7 +1132,7 @@ internal sealed class HarvestingContractExecutionController
                 onlyOnline: true);
             return requester is not null
                 && ReferenceEquals(requester.currentLocation, contract.Farm)
-                && AnimalProductTransferService.CanInventoryAcceptCompleteStack(
+                && RequesterInventoryCapacity.CanAcceptCompleteStack(
                     requester,
                     item);
         }
@@ -1326,7 +1326,7 @@ internal sealed class HarvestingContractExecutionController
         bool requesterIsOnMainFarm = requesterIsOnline
             && ReferenceEquals(requester!.currentLocation, contract.Farm);
         bool canAcceptCompleteStack = requesterIsOnline
-            && CanInventoryAcceptCompleteStack(requester!, entry.Item);
+            && RequesterInventoryCapacity.CanAcceptCompleteStack(requester!, entry.Item);
         HarvestDestinationAction action = HarvestDestinationPolicy.SelectAction(
             contract.DestinationMode,
             requesterIsOnline,
@@ -1427,27 +1427,6 @@ internal sealed class HarvestingContractExecutionController
         return requester.Items
             .Where(item => item is not null && sample.canStackWith(item))
             .Sum(item => item?.Stack ?? 0);
-    }
-
-    private static bool CanInventoryAcceptCompleteStack(Farmer requester, Item item)
-    {
-        if (item.IsRecipe
-            || item.QualifiedItemId is "(O)73" or "(O)930" or "(O)102" or "(O)858" or "(O)GoldCoin")
-            return true;
-
-        for (int index = 0; index < requester.MaxItems && index < requester.Items.Count; index++)
-        {
-            Item? existing = requester.Items[index];
-            if (existing is null)
-                return true;
-            if (item is StardewValley.Object
-                && existing is StardewValley.Object
-                && existing.Stack + item.Stack <= existing.maximumStackSize()
-                && existing.canStackWith(item))
-                return true;
-        }
-
-        return false;
     }
 
     private void OnChestLockAcquired(Guid contractId, HarvestChestRoute route)

--- a/src/RequesterInventoryCapacity.cs
+++ b/src/RequesterInventoryCapacity.cs
@@ -1,0 +1,69 @@
+using StardewValley;
+
+namespace EvilFarmOwner;
+
+internal readonly record struct InventoryCapacitySlot(
+    bool IsEmpty,
+    bool IsCompatible,
+    int CurrentStack,
+    int MaximumStack);
+
+internal static class InventoryCapacityPolicy
+{
+    public static bool CanAcceptCompleteStack(
+        int requestedStack,
+        int incomingMaximumStack,
+        IEnumerable<InventoryCapacitySlot> slots)
+    {
+        ArgumentNullException.ThrowIfNull(slots);
+        if (requestedStack <= 0)
+            return true;
+
+        long capacity = 0;
+        foreach (InventoryCapacitySlot slot in slots)
+        {
+            if (slot.IsEmpty)
+                capacity += Math.Max(1, incomingMaximumStack);
+            else if (slot.IsCompatible)
+                capacity += Math.Max(0, slot.MaximumStack - slot.CurrentStack);
+
+            if (capacity >= requestedStack)
+                return true;
+        }
+
+        return false;
+    }
+}
+
+internal static class RequesterInventoryCapacity
+{
+    public static bool CanAcceptCompleteStack(Farmer requester, Item item)
+    {
+        ArgumentNullException.ThrowIfNull(requester);
+        ArgumentNullException.ThrowIfNull(item);
+        if (item.IsRecipe
+            || item.QualifiedItemId is "(O)73" or "(O)930" or "(O)102" or "(O)858" or "(O)GoldCoin")
+            return true;
+
+        int usableSlots = Math.Max(0, requester.MaxItems);
+        InventoryCapacitySlot[] slots = new InventoryCapacitySlot[usableSlots];
+        for (int index = 0; index < usableSlots; index++)
+        {
+            Item? existing = index < requester.Items.Count
+                ? requester.Items[index]
+                : null;
+            slots[index] = existing is null
+                ? new InventoryCapacitySlot(true, false, 0, 0)
+                : new InventoryCapacitySlot(
+                    false,
+                    existing.canStackWith(item),
+                    existing.Stack,
+                    existing.maximumStackSize());
+        }
+
+        return InventoryCapacityPolicy.CanAcceptCompleteStack(
+            item.Stack,
+            item.maximumStackSize(),
+            slots);
+    }
+}

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -35,6 +35,7 @@ List<(string Name, Action Test)> tests = new()
     ("animal loose product ownership", TestAnimalLooseProductOwnership),
     ("animal product route ordering", TestAnimalProductRouteOrdering),
     ("animal product commit preflight", TestAnimalProductCommitPreflight),
+    ("requester inventory aggregate capacity", TestRequesterInventoryAggregateCapacity),
     ("recurring contract state validation", TestRecurringContractStateValidation),
     ("recurring contract candidate pool", TestRecurringContractCandidatePool),
     ("recurring contract ranking", TestRecurringContractRanking),
@@ -705,6 +706,39 @@ static void TestAnimalProductCommitPreflight()
         AnimalProductCommitPolicy.EvaluatePreflight(true, true, 1, 2));
     Throws<ArgumentOutOfRangeException>(() =>
         AnimalProductCommitPolicy.EvaluatePreflight(true, true, 0, 0));
+}
+
+static void TestRequesterInventoryAggregateCapacity()
+{
+    InventoryCapacitySlot[] splitCompatibleCapacity =
+    {
+        new(false, true, 970, 999),
+        new(false, false, 1, 1),
+        new(false, true, 950, 999)
+    };
+    Equal(true, InventoryCapacityPolicy.CanAcceptCompleteStack(
+        requestedStack: 70,
+        incomingMaximumStack: 999,
+        splitCompatibleCapacity));
+    Equal(false, InventoryCapacityPolicy.CanAcceptCompleteStack(
+        requestedStack: 79,
+        incomingMaximumStack: 999,
+        splitCompatibleCapacity));
+
+    InventoryCapacitySlot[] emptySlots =
+    {
+        new(false, false, 1, 1),
+        new(true, false, 0, 0),
+        new(true, false, 0, 0)
+    };
+    Equal(true, InventoryCapacityPolicy.CanAcceptCompleteStack(
+        requestedStack: 1500,
+        incomingMaximumStack: 999,
+        emptySlots));
+    Equal(false, InventoryCapacityPolicy.CanAcceptCompleteStack(
+        requestedStack: 1999,
+        incomingMaximumStack: 999,
+        emptySlots));
 }
 
 static void TestRecurringContractStateValidation()


### PR DESCRIPTION
## Summary

Fixes requester-inventory preflight by summing capacity across all compatible partial stacks and usable empty slots. Harvest cargo and animal products now share one implementation, while special immediately consumed items and whole-stack fail-closed commits remain unchanged.

## Linked Issue

Closes #118

## Change Type

- [ ] `feat`: user-facing feature
- [x] `fix`: bug fix
- [ ] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [ ] `test`: test or validation work

## Validation

- [x] Built locally with `dotnet build -c Release` (deployment and ZIP disabled)
- [ ] Launched with SMAPI
- [ ] Tested in a save file
- [x] Multiplayer impact considered
- [x] Documentation updated if user-facing behavior changed

Build result: 0 warnings, 0 errors. Deterministic logic harness: 114/114 passed. `git diff --check` passed.

## Notes

Host authority and protocol messages are unchanged. No in-game acceptance was performed, per maintainer direction.