### PR TITLE
fix(harvest): allow off-farm crab pot bonus delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed Crabbing Book bonus preflight so an online requester with sufficient inventory capacity remains eligible after leaving the farm, matching the contract's cross-map delivery rule.
 - Fixed requester-inventory preflight to count aggregate space across every compatible partial stack and usable empty slot for both harvest cargo and animal products.
 - Batched classified-chest harvest cargo behind a 12-stack delivery threshold, then grouped carried outputs by their live best destination so each chest is visited and locked once per batch while retaining independent lossless transfer identities.
 - Added host-authoritative wage and complete-shift preferences through Generic Mod Config Menu: base hourly wage, friendship impact, rest-day multiplier, default harvest destination, and per-stage enablement with immutable contract snapshots and multiplayer synchronization.

--- a/src/HarvestDestinationPolicy.cs
+++ b/src/HarvestDestinationPolicy.cs
@@ -47,6 +47,19 @@ internal static class HarvestDestinationPolicy
                 : HarvestDestinationAction.StopUnavailable;
     }
 
+    public static bool CanRequesterInventoryAccept(
+        bool requesterIsOnline,
+        bool requesterIsOnMainFarm,
+        bool requesterCanAcceptCompleteStack)
+    {
+        return SelectAction(
+                HarvestDestinationMode.RequesterInventory,
+                requesterIsOnline,
+                requesterIsOnMainFarm,
+                requesterCanAcceptCompleteStack)
+            == HarvestDestinationAction.DeliverToRequester;
+    }
+
     public static int GetRetainedCount(
         int compatibleQuantityBefore,
         int compatibleQuantityAfter,

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -1130,11 +1130,15 @@ internal sealed class HarvestingContractExecutionController
             Farmer? requester = Game1.GetPlayer(
                 contract.Requester.UniqueMultiplayerID,
                 onlyOnline: true);
-            return requester is not null
-                && ReferenceEquals(requester.currentLocation, contract.Farm)
-                && RequesterInventoryCapacity.CanAcceptCompleteStack(
-                    requester,
-                    item);
+            bool requesterIsOnline = requester is not null;
+            bool requesterIsOnMainFarm = requesterIsOnline
+                && ReferenceEquals(requester!.currentLocation, contract.Farm);
+            bool canAcceptCompleteStack = requesterIsOnline
+                && RequesterInventoryCapacity.CanAcceptCompleteStack(requester!, item);
+            return HarvestDestinationPolicy.CanRequesterInventoryAccept(
+                requesterIsOnline,
+                requesterIsOnMainFarm,
+                canAcceptCompleteStack);
         }
 
         return this.ChestRouter.FindBestRoute(

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -1466,6 +1466,18 @@ static void TestHarvestContractDestinationPolicy()
             requesterIsOnline: false,
             requesterIsOnMainFarm: false,
             requesterCanAcceptCompleteStack: true));
+    Equal(true, HarvestDestinationPolicy.CanRequesterInventoryAccept(
+        requesterIsOnline: true,
+        requesterIsOnMainFarm: false,
+        requesterCanAcceptCompleteStack: true));
+    Equal(false, HarvestDestinationPolicy.CanRequesterInventoryAccept(
+        requesterIsOnline: false,
+        requesterIsOnMainFarm: false,
+        requesterCanAcceptCompleteStack: true));
+    Equal(false, HarvestDestinationPolicy.CanRequesterInventoryAccept(
+        requesterIsOnline: true,
+        requesterIsOnMainFarm: false,
+        requesterCanAcceptCompleteStack: false));
     Equal(0, HarvestDestinationPolicy.GetRetainedCount(20, 20, 7));
     Equal(3, HarvestDestinationPolicy.GetRetainedCount(20, 23, 7));
     Equal(7, HarvestDestinationPolicy.GetRetainedCount(20, 29, 7));


### PR DESCRIPTION
## Summary

Aligns Crabbing Book doubled-output preflight with the existing requester-inventory contract rule. An online requester with aggregate capacity remains eligible across maps; offline or capacity-insufficient requesters remain fail-closed. Classified-chest routing, deterministic rolls, and vanilla output semantics are unchanged.

## Linked Issue

Closes #120

## Change Type

- [ ] `feat`: user-facing feature
- [x] `fix`: bug fix
- [ ] `docs`: documentation only
- [ ] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [ ] `test`: test or validation work

## Validation

- [x] Built locally with `dotnet build -c Release` (deployment and ZIP disabled)
- [ ] Launched with SMAPI
- [ ] Tested in a save file
- [x] Multiplayer impact considered
- [x] Documentation updated if user-facing behavior changed

Build result: 0 warnings, 0 errors. Deterministic logic harness: 114/114 passed. `git diff --check` passed.

## Notes

No protocol schema changes. No in-game acceptance was performed, per maintainer direction.