### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-26
+
 - Fixed Crabbing Book bonus preflight so an online requester with sufficient inventory capacity remains eligible after leaving the farm, matching the contract's cross-map delivery rule.
 - Fixed requester-inventory preflight to count aggregate space across every compatible partial stack and usable empty slot for both harvest cargo and animal products.
 - Batched classified-chest harvest cargo behind a 12-stack delivery threshold, then grouped carried outputs by their live best destination so each chest is visited and locked once per batch while retaining independent lossless transfer identities.

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <AssemblyName>EvilFarmOwner</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Aveouter/EvilFarmOwner</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </h1>
 
 <p align="center">
-  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.2.0
+  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.3.0
 </p>
 
 <p align="center">
@@ -55,7 +55,7 @@
 
 没有工作的阶段会自动跳过。个别目标无法到达时，工人会尝试换路或跳过；安全条件失效时合同会明确停止，不会破坏农场摆设。
 
-使用分类箱时，NPC 会连续收集产物，达到 12 个独立堆叠的送货阈值后再集中前往箱子；目标已经采完或接近停止采集时间时也会立即送货。玩家背包模式仍即时交付，因为它不需要 NPC 往返。
+使用分类箱时，NPC 会连续收集产物，达到 12 个独立堆叠的送货阈值后再集中送货，并按目标箱分组，每个箱子只走访和加锁一次；目标已经采完或接近停止采集时间时也会立即送货。玩家背包模式仍即时交付，因为它不需要 NPC 往返。
 
 玩家离开农场后，NPC 仍会在农场继续工作。当前同一时间只能执行一份合同、雇佣一名工人。
 
@@ -151,7 +151,7 @@ A contract performs every currently ready stage in this order:
 
 Empty stages are skipped. The worker replans or skips isolated unreachable targets and stops explicitly when safety conditions change instead of destroying placed objects.
 
-With classified chests selected, the NPC keeps collecting until reaching a 12-stack delivery threshold, then makes a consolidated storage run. Cargo is also delivered when no target remains or the acquisition cutoff is reached. Requester-inventory delivery remains immediate because it requires no NPC round trip.
+With classified chests selected, the NPC keeps collecting until reaching a 12-stack delivery threshold, then groups cargo by destination so each chest is visited and locked once. Cargo is also delivered when no target remains or the acquisition cutoff is reached. Requester-inventory delivery remains immediate because it requires no NPC round trip.
 
 The NPC continues working on the farm when the player changes maps. Only one contract and one worker can run at a time in the current version.
 

--- a/docs/RELEASE_NOTES_0.3.0.md
+++ b/docs/RELEASE_NOTES_0.3.0.md
@@ -1,0 +1,43 @@
+# Evil Farm Owner v0.3.0
+
+## 中文
+
+v0.3.0 让完整农活班次更容易按自己的玩法调整，也减少了 NPC 在收获与储存之间的无效往返。
+
+### 主要更新
+
+- 安装可选的 Generic Mod Config Menu 后，主机可以设置基础时薪、好感度对工资的影响、休息日倍率、默认产物去向，以及是否启用收获、浇水、动物照料和箱子整理。
+- 分类箱模式会先连续收集最多 12 个独立产物堆叠，再按照现有的同品质堆叠、同物品、同类别和空箱规则分组送货；同一批中属于同一箱子的物品只走访并锁定箱子一次。
+- 修复玩家背包明明能通过多个未满堆叠共同容纳产物，却被错误判断为没有空间的问题。收获物和动物产物现在使用同一套完整容量判断。
+- 修复玩家离开农场后，蟹笼的《捕蟹秘籍》双倍产物可能被错误取消的问题。只要玩家在线且背包容量足够，跨地图接收仍然有效。
+
+### 安全与兼容
+
+- 每件已取得的物品仍保留独立的转移记录；分类、容量和箱子状态会在主机持有箱锁时重新检查。
+- 运行中的合同使用开工时保存的设置，不会被中途修改。
+- 多人游戏仍由主机执行工作和修改金币、NPC、作物、动物与储存；所有玩家必须安装完全相同的 Mod 版本。
+- 需要 Stardew Valley 1.6+、SMAPI 4.0+；Generic Mod Config Menu 为可选依赖。
+
+## English
+
+v0.3.0 makes complete farm-work shifts easier to tune and reduces wasted travel between collection targets and storage.
+
+### Highlights
+
+- With the optional Generic Mod Config Menu installed, the host can configure the base hourly wage, friendship discount strength, rest-day multiplier, default output destination, and whether harvesting, watering, animal care, and chest sorting are enabled.
+- Classified-chest delivery now carries up to 12 independent output stacks, groups them through the existing compatible-quality, same-item, exact-category, and empty-chest rules, then visits and locks each selected chest once per batch.
+- Fixed requester inventory checks which rejected output even when several compatible partial stacks had enough combined space. Harvest cargo and animal products now share one complete-capacity calculation.
+- Fixed the Crabbing Book doubled crab-pot output being suppressed after the requester left the farm. Cross-map delivery remains valid while that player is online and has enough inventory capacity.
+
+### Safety and compatibility
+
+- Every captured output keeps its independent transfer record. Classification, capacity, and live chest state are rechecked while the host owns the chest mutex.
+- A running contract keeps the settings snapshot taken when the shift began.
+- Multiplayer work and mutations remain host-authoritative, and every player must install the exact same mod version.
+- Requires Stardew Valley 1.6+ and SMAPI 4.0+. Generic Mod Config Menu remains optional.
+
+## Deferred manual acceptance / 延期人工验收
+
+The deterministic suite, clean Release build, package allowlist, manifest, license, translation parity, production-DLL scan, and published download checksum are automated release gates. Per maintainer direction, this cycle does not launch the game. The forced-storage fault matrix, real two-process multiplayer test, final visual review, and exact published-ZIP in-game smoke test remain unperformed and are not claimed as passed.
+
+确定性测试、干净 Release 构建、包内容白名单、清单、许可证、翻译键一致性、生产 DLL 扫描及公开下载哈希属于自动发布门禁。按照维护者要求，本轮不启动游戏。强制储存故障矩阵、真实双进程多人、最终视觉检查和精确发布 ZIP 的游戏内烟雾测试仍未执行，也不会被声明为已通过。

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Evil Farm Owner",
   "Author": "Aveouter",
-  "Version": "0.2.0",
+  "Version": "0.3.0",
   "Description": "Hire available adult NPCs for complete visible farm-work shifts with safe harvest delivery.",
   "UniqueID": "Aveouter.EvilFarmOwner",
   "EntryDll": "EvilFarmOwner.dll",


### PR DESCRIPTION
## Summary

Prepares the v0.3.0 minor release with aligned project/manifest/README versions, a dated changelog section, and bilingual user-facing release notes for configurable contracts, grouped batch delivery, aggregate inventory capacity, and off-farm crab-pot bonus delivery.

## Linked Issue

Part of #122

## Change Type

- [ ] `feat`: user-facing feature
- [ ] `fix`: bug fix
- [x] `docs`: documentation only
- [x] `chore`: project, build, or maintenance work
- [ ] `refactor`: internal code change without behavior change
- [ ] `test`: test or validation work

## Validation

- [x] Built locally with `dotnet build -c Release`
- [ ] Launched with SMAPI
- [ ] Tested in a save file
- [x] Multiplayer impact considered
- [x] Documentation updated if user-facing behavior changed

Clean `./scripts/verify-release.sh` passed from source tree `88a8235a140e6d982b8c6613a9fc063131041e49`:

- 114/114 deterministic tests passed
- Release rebuild: 0 warnings, 0 errors
- ZIP allowlist, manifest, MIT license, and production DLL scan passed
- Candidate SHA-256: `433261005f1e232431e53309aa245f17ce985c4eda294818071a7de00dce10c6`

## Notes

Per maintainer direction, this cycle does not launch the game. Release notes continue to disclose the unperformed forced-storage, real two-process multiplayer, visual, and exact published-ZIP in-game acceptance gates.