### PR TITLE
fix(harvest): count simulated carried slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed the 12-slot harvest delivery threshold to count simulated vanilla-compatible carried slots instead of individual capture records, while retaining independent transfer identities.
 ## 0.3.0 - 2026-08-26
 
 - Fixed Crabbing Book bonus preflight so an online requester with sufficient inventory capacity remains eligible after leaving the farm, matching the contract's cross-map delivery rule.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 没有工作的阶段会自动跳过。个别目标无法到达时，工人会尝试换路或跳过；安全条件失效时合同会明确停止，不会破坏农场摆设。
 
-使用分类箱时，NPC 会连续收集产物，达到 12 个独立堆叠的送货阈值后再集中送货，并按目标箱分组，每个箱子只走访和加锁一次；目标已经采完或接近停止采集时间时也会立即送货。玩家背包模式仍即时交付，因为它不需要 NPC 往返。
+使用分类箱时，NPC 会连续收集产物，按照原版可堆叠规则模拟携带空间，达到 12 个实际物品格后再集中送货；同物品同品质会共用一格，而不是每件作物各占一格。送货时按目标箱分组，每个箱子只走访和加锁一次；目标已经采完或接近停止采集时间时也会立即送货。玩家背包模式仍即时交付，因为它不需要 NPC 往返。
 
 玩家离开农场后，NPC 仍会在农场继续工作。当前同一时间只能执行一份合同、雇佣一名工人。
 
@@ -151,7 +151,7 @@ A contract performs every currently ready stage in this order:
 
 Empty stages are skipped. The worker replans or skips isolated unreachable targets and stops explicitly when safety conditions change instead of destroying placed objects.
 
-With classified chests selected, the NPC keeps collecting until reaching a 12-stack delivery threshold, then groups cargo by destination so each chest is visited and locked once. Cargo is also delivered when no target remains or the acquisition cutoff is reached. Requester-inventory delivery remains immediate because it requires no NPC round trip.
+With classified chests selected, the NPC simulates vanilla-compatible stacking and keeps collecting until the cargo occupies 12 actual slots; compatible items share a slot instead of every crop counting separately. Delivery then groups cargo by destination so each chest is visited and locked once. Cargo is also delivered when no target remains or the acquisition cutoff is reached. Requester-inventory delivery remains immediate because it requires no NPC round trip.
 
 The NPC continues working on the farm when the player changes maps. Only one contract and one worker can run at a time in the current version.
 

--- a/src/HarvestCargoBatchPolicy.cs
+++ b/src/HarvestCargoBatchPolicy.cs
@@ -19,6 +19,48 @@ internal static class HarvestCargoBatchPolicy
                 || noRemainingTarget);
     }
 
+    public static int CountCarriedSlots<T>(
+        IEnumerable<T> cargo,
+        Func<T, int> getQuantity,
+        Func<T, int> getMaximumStack,
+        Func<T, T, bool> canStack)
+    {
+        ArgumentNullException.ThrowIfNull(cargo);
+        ArgumentNullException.ThrowIfNull(getQuantity);
+        ArgumentNullException.ThrowIfNull(getMaximumStack);
+        ArgumentNullException.ThrowIfNull(canStack);
+
+        List<CarriedSlot<T>> slots = new();
+        foreach (T entry in cargo)
+        {
+            int remaining = Math.Max(0, getQuantity(entry));
+            if (remaining == 0)
+                continue;
+
+            int maximumStack = Math.Max(1, getMaximumStack(entry));
+            foreach (CarriedSlot<T> slot in slots)
+            {
+                if (remaining == 0)
+                    break;
+                if (!canStack(slot.Sample, entry))
+                    continue;
+
+                int accepted = Math.Min(remaining, Math.Max(0, slot.MaximumStack - slot.Quantity));
+                slot.Quantity += accepted;
+                remaining -= accepted;
+            }
+
+            while (remaining > 0)
+            {
+                int quantity = Math.Min(remaining, maximumStack);
+                slots.Add(new CarriedSlot<T>(entry, quantity, maximumStack));
+                remaining -= quantity;
+            }
+        }
+
+        return slots.Count;
+    }
+
     public static IReadOnlyList<string> SelectForChest(
         IEnumerable<HarvestCargoDestination> destinations,
         GridPoint chestTile)
@@ -28,5 +70,19 @@ internal static class HarvestCargoBatchPolicy
             .Where(destination => destination.ChestTile == chestTile)
             .Select(destination => destination.TransferId)
             .ToArray();
+    }
+
+    private sealed class CarriedSlot<T>
+    {
+        public CarriedSlot(T sample, int quantity, int maximumStack)
+        {
+            this.Sample = sample;
+            this.Quantity = quantity;
+            this.MaximumStack = maximumStack;
+        }
+
+        public T Sample { get; }
+        public int Quantity { get; set; }
+        public int MaximumStack { get; }
     }
 }

--- a/src/HarvestingContractExecutionController.cs
+++ b/src/HarvestingContractExecutionController.cs
@@ -1621,7 +1621,7 @@ internal sealed class HarvestingContractExecutionController
             HarvestDestinationMode.RequesterInventory;
         bool acquisitionClosed = Game1.timeOfDay >= StopAcquiringTime;
         if (deliverImmediately || HarvestCargoBatchPolicy.ShouldDeliver(
-                contract.Cargo.Count,
+                this.CountCarriedSlots(contract),
                 acquisitionClosed,
                 noRemainingTarget: false))
         {
@@ -1686,7 +1686,7 @@ internal sealed class HarvestingContractExecutionController
                     LogLevel.Warn);
             }
             if (HarvestCargoBatchPolicy.ShouldDeliver(
-                    contract.Cargo.Count,
+                    this.CountCarriedSlots(contract),
                     acquisitionClosed: false,
                     noRemainingTarget: true))
                 this.BeginDeliveryOrReturn(contract);
@@ -1738,6 +1738,15 @@ internal sealed class HarvestingContractExecutionController
                 contract,
                 $"controller setup failed: {ex.Message}");
         }
+    }
+
+    private int CountCarriedSlots(ActiveHarvestContract contract)
+    {
+        return HarvestCargoBatchPolicy.CountCarriedSlots(
+            contract.Cargo,
+            entry => entry.Item.Stack,
+            entry => entry.Item.maximumStackSize(),
+            (left, right) => left.Item.canStackWith(right.Item));
     }
 
     private void BeginReturn(ActiveHarvestContract contract, bool depositOverflowOnReturn)

--- a/tests/Program.cs
+++ b/tests/Program.cs
@@ -91,6 +91,7 @@ List<(string Name, Action Test)> tests = new()
     ("harvest partial remainder", TestHarvestPartialRemainder),
     ("harvest chest release deferral", TestHarvestChestReleaseDeferral),
     ("harvest cargo batch threshold", TestHarvestCargoBatchThreshold),
+    ("harvest cargo carried slot count", TestHarvestCargoCarriedSlotCount),
     ("harvest cargo destination grouping", TestHarvestCargoDestinationGrouping),
     ("regrowing harvest capture semantics", TestRegrowingHarvestCaptureSemantics),
     ("ready tapper target semantics", TestReadyTapperTargetSemantics),
@@ -2130,6 +2131,38 @@ static void TestHarvestCargoBatchThreshold()
         noRemainingTarget: true));
 }
 
+static void TestHarvestCargoCarriedSlotCount()
+{
+    CargoSlotSample[] identical = Enumerable.Range(0, 12)
+        .Select(_ => new CargoSlotSample("cauliflower-q0", 1, 999))
+        .ToArray();
+    Equal(1, CountCargoSlots(identical));
+
+    CargoSlotSample[] qualities =
+    {
+        new("cauliflower-q0", 8, 999),
+        new("cauliflower-q1", 3, 999),
+        new("cauliflower-q2", 1, 999)
+    };
+    Equal(3, CountCargoSlots(qualities));
+
+    CargoSlotSample[] overflow =
+    {
+        new("wood", 1200, 999),
+        new("wood", 900, 999)
+    };
+    Equal(3, CountCargoSlots(overflow));
+}
+
+static int CountCargoSlots(IEnumerable<CargoSlotSample> cargo)
+{
+    return HarvestCargoBatchPolicy.CountCarriedSlots(
+        cargo,
+        entry => entry.Quantity,
+        entry => entry.MaximumStack,
+        (left, right) => left.StackingKey == right.StackingKey);
+}
+
 static void TestHarvestCargoDestinationGrouping()
 {
     GridPoint vegetables = new(10, 4);
@@ -3264,3 +3297,8 @@ static void Throws<TException>(Action action, [CallerLineNumber] int line = 0)
     throw new InvalidOperationException(
         $"line={line}, expected exception={typeof(TException).Name}");
 }
+
+readonly record struct CargoSlotSample(
+    string StackingKey,
+    int Quantity,
+    int MaximumStack);


### PR DESCRIPTION
## Summary

Changes the 12-slot classified-chest delivery threshold from capture-record count to simulated vanilla-compatible carried slots. Compatible item metadata and quality share capacity up to the item maximum stack size, while every capture keeps its independent transfer ID.

## Linked Issue

Closes #124

## Change Type

- [x] `fix`: bug fix
- [x] Documentation updated

## Validation

- [x] Release build: 0 warnings, 0 errors (deploy/ZIP disabled)
- [x] Deterministic tests: 115/115 passed
- [x] `git diff --check` passed
- [x] Multiplayer impact considered: host execution/protocol unchanged
- [ ] New build tested in game

The live v0.3.0 report is the reproduction evidence. A rebuilt DLL will be deployed only after the running game exits.