### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+## 0.3.1 - 2026-08-26
+
 - Fixed the 12-slot harvest delivery threshold to count simulated vanilla-compatible carried slots instead of individual capture records, while retaining independent transfer identities.
 - Replanned stalled classified-chest deliveries around the exact failed next tile, and added structured route diagnostics plus a localized HUD reason with worker, origin, and chest coordinates.
+
 ## 0.3.0 - 2026-08-26
 
 - Fixed Crabbing Book bonus preflight so an online requester with sufficient inventory capacity remains eligible after leaving the farm, matching the contract's cross-map delivery rule.

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <AssemblyName>EvilFarmOwner</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Aveouter/EvilFarmOwner</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </h1>
 
 <p align="center">
-  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.3.0
+  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.3.1
 </p>
 
 <p align="center">

--- a/docs/RELEASE_NOTES_0.3.1.md
+++ b/docs/RELEASE_NOTES_0.3.1.md
@@ -1,0 +1,41 @@
+# Evil Farm Owner v0.3.1
+
+## 中文
+
+v0.3.1 是一个仅包含收获送货修复的稳定性补丁。
+
+### 修复内容
+
+- NPC 的 12 格携带上限现在按原版可堆叠规则计算。同物品、同品质的产物会共用一个物品格，不再把每次采集记录误算为独立格子。
+- 收获产物送往分类箱时，如果路线动态卡住，NPC 会排除失败的下一格并重新规划，而不是连续重试同一段路线。
+- 如果三次安全路线都失败，画面会显示工人、起点、箱子和具体中断原因；SMAPI 日志还会记录像素坐标、下一路径点、控制器状态和实时碰撞探测。
+
+### 安全与兼容
+
+- 每件产物仍保留独立转移编号；批量携带不会改变箱子分类、容量检查或物品守恒规则。
+- 无法完成送货时，已有产物仍进入原有的受保护恢复流程，不会静默消失。
+- 本补丁不改变配置、多人协议、存档结构或同时可雇佣的工人数。
+- 需要 Stardew Valley 1.6+、SMAPI 4.0+；Generic Mod Config Menu 仍为可选依赖。
+
+## English
+
+v0.3.1 is a narrowly scoped stability patch for harvest delivery.
+
+### Fixes
+
+- The NPC's 12-slot carrying threshold now follows vanilla-compatible stacking. Compatible items with the same quality share one carried slot instead of every capture record counting separately.
+- When a classified-chest delivery route stalls dynamically, the worker excludes the failed next tile and replans instead of retrying the same broken segment.
+- If all three safe routes fail, the HUD identifies the worker, origin, chest, and interruption reason. The SMAPI log also records pixel coordinates, the next waypoint, controller state, and a live collision probe.
+
+### Safety and compatibility
+
+- Every output keeps its independent transfer ID. Batched carrying does not change chest classification, capacity checks, or conservation accounting.
+- If delivery cannot finish, captured cargo still enters the existing protected recovery path and is never silently discarded.
+- This patch does not change configuration, multiplayer protocol, save data, or the one-worker concurrency limit.
+- Requires Stardew Valley 1.6+ and SMAPI 4.0+. Generic Mod Config Menu remains optional.
+
+## Release verification / 发布验证
+
+The exact release ZIP must pass the clean deterministic suite, package allowlist, production-DLL scan, SHA-256 re-download audit, and SMAPI load smoke test before the draft release is made public. The forced-storage fault matrix and real two-process multiplayer acceptance remain deferred and are not claimed as passed by this patch.
+
+正式公开前，精确发布 ZIP 必须通过干净的确定性测试、包内容白名单、生产 DLL 扫描、重新下载 SHA-256 校验和 SMAPI 加载烟雾测试。本补丁仍不声明强制储存故障矩阵或真实双进程多人验收已经完成。

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Evil Farm Owner",
   "Author": "Aveouter",
-  "Version": "0.3.0",
+  "Version": "0.3.1",
   "Description": "Hire available adult NPCs for complete visible farm-work shifts with safe harvest delivery.",
   "UniqueID": "Aveouter.EvilFarmOwner",
   "EntryDll": "EvilFarmOwner.dll",


### PR DESCRIPTION
## Summary
- bump project, manifest, and README metadata to v0.3.1
- move the two already-merged harvest-delivery fixes from Unreleased into the v0.3.1 changelog
- add bilingual, user-facing v0.3.1 release notes with an explicit scope and verification statement

## Validation
- `./scripts/verify-release.sh`
- 116/116 deterministic logic tests passed
- Release build: 0 warnings, 0 errors
- Package allowlist and production-DLL scan passed
- Candidate SHA-256: `770e6bbcc4005caab6aca49603a4219729d9452f8a90ffecefee96068ece9da5`

Closes #128