### PR TITLE
chore(release): prepare v0.3.2 route reliability release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.2 - 2026-08-26
 
 - Added a shared primitive-only travel interruption snapshot and map-scoped tile/edge obstacle ledger for bounded route recovery across farm-work controllers.
 - Applied detailed interruption logs, map-scoped dynamic obstacle avoidance, and a localized final HUD reason to watering and harvest-target travel while preserving the existing bounded target-skip policy.

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
     <AssemblyName>EvilFarmOwner</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Aveouter/EvilFarmOwner</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </h1>
 
 <p align="center">
-  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.3.1
+  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.3.2
 </p>
 
 <p align="center">

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,102 +1,41 @@
 # Project Plan
 
-This document defines the issue taxonomy, milestone structure, and development order for Evil Farm Owner.
+This document records the active release order and the repository's issue-first development rules.
 
-## Issue Taxonomy
+## Development workflow
 
-Every issue should have one label from each group when possible.
+Every implementation starts from an issue with one `type`, `priority`, `area`, and `status` label. Work branches from current `main`, lands through a focused pull request, passes repository checks and review, and is squash-merged. Release candidates additionally require the clean local verifier because hosted CI cannot compile against proprietary Stardew Valley assemblies.
 
-### Type
+## Released baseline
 
-- `type:feature`: user-facing behavior or feature.
-- `type:bug`: confirmed defect or unsafe behavior.
-- `type:design`: gameplay, UX, or architecture decision before implementation.
-- `type:tech-debt`: internal cleanup or structure work.
-- `type:docs`: user docs, contributor docs, templates, or project process.
-- `type:idea`: unscheduled future concept.
+- `v0.3.0` provides complete single-worker shifts, configurable wages and stages, batched lossless harvest delivery, animal care, chest sorting, and host-authoritative protocol 9 behavior.
+- `v0.3.1` is the narrow harvest-delivery hotfix: vanilla-compatible 12-slot accounting plus detailed classified-chest delivery recovery.
 
-### Priority
+## Current release: v0.3.2 - Route reliability
 
-- `priority:p0`: save corruption, data loss, or release blocker.
-- `priority:p1`: current milestone priority.
-- `priority:p2`: important but not blocking the current milestone.
-- `priority:p3`: later exploration.
+`v0.3.2` is a single-worker stability release. It does not change the multiplayer protocol, save schema, hiring flow, or worker limit.
 
-### Area
+Completed implementation gates:
 
-- `area:ui`: menus, HUD, input flow, and player interaction.
-- `area:farm-work`: watering, harvesting, planting, fertilizing, debris cleanup.
-- `area:storage`: chests, warehouse, routing, sorting, inventory movement.
-- `area:multiplayer`: host/client behavior and sync.
-- `area:npc`: worker identity, visuals, movement, and NPC-like behavior.
-- `area:config`: settings and persistence.
-- `area:docs`: README and contributor-facing documentation.
-- `area:release`: packaging, versioning, and release workflow.
+- shared route interruption classification and diagnostic snapshots;
+- location-scoped blocked tiles and directed edges;
+- three-attempt bounded replanning for harvest, watering, animal care, and chest sorting;
+- non-destructive farm routing with gate opening;
+- explicit target-skip, safe-return, and lossless cargo recovery policies;
+- a standalone .NET 8 Core project with all deterministic tests running on Ubuntu CI.
 
-### Status
+Release gates still requiring recorded evidence:
 
-- `status:needs-design`: not ready to code yet.
-- `status:ready`: ready for implementation.
-- `status:blocked`: blocked by another decision, issue, or external constraint.
+- disposable-save route matrix covering dynamic obstacles, dense/trellis crops, animal-house doors, player map changes, sorting routes, and return travel;
+- forced storage recovery matrix covering overflow, visible drop, quarantine, recovery records, save, and reload;
+- clean production package, allowlist, command scan, SHA-256 re-download audit, and exact-ZIP SMAPI load smoke test.
 
-## Milestones
+## Next release: v0.5.0 - Concurrent workers
 
-### v0.1.0 - First Public Release
+Concurrent execution remains disabled by default and the current limit remains one worker. `v0.5.0` will add a host-owned `MaximumConcurrentWorkers` setting with a range of 1–4 and default 1, stable automatic hiring, independent worker leases/routes/cargo/settlement, task claims and reassignment, route and entrance reservations, chest locks, protocol migration, and old-save compatibility.
 
-Ship the first public version with the complete named-worker baseline.
+The release gate includes deterministic 1–4 worker behavior, one-worker equivalence, save/reload, day end, host restart, farmhand reconnect, storage contention, and a real two-process host/farmhand acceptance run. Until that gate passes, documentation must not claim concurrent or fully verified remote multiplayer support.
 
-Focus:
+## Deferred ideas
 
-- Provide one visible named-worker shift that completes all currently supported farm work.
-- Deliver harvest output without silent item loss.
-- Support host-authoritative network multiplayer requests and synchronization.
-- Improve packaging and release hygiene.
-
-### v0.2.0 - Hiring Menu MVP
-
-Turn the prototype into a player-facing interaction.
-
-Focus:
-
-- Add a hiring menu.
-- Show enabled jobs.
-- Show wage before confirmation.
-- Let players confirm or cancel.
-- Preserve console commands for testing.
-
-### v0.3.0 - Worker Identity & Feedback
-
-Make farmhands feel like hired workers instead of invisible scripts.
-
-Focus:
-
-- Worker names or contracts.
-- Work result messages.
-- Better feedback for unavailable work.
-- First version of worker presence or simple visuals.
-
-### v0.4.0 - Storage & Warehouse Jobs
-
-Add storage automation.
-
-Focus:
-
-- Define harvest output routing.
-- Add chest sorting rules.
-- Add warehouse or storage anchor design.
-- Move items safely without losing stacks.
-
-### v0.5.0 - Multiplayer Support
-
-Make multiplayer behavior explicit and reliable.
-
-Focus:
-
-- Host-authoritative work execution.
-- Client work requests.
-- Sync user-facing messages.
-- Avoid duplicate work passes.
-
-## Current Priority
-
-`v0.1.0` has been published. The current development phase prepares safe multi-worker execution one independently testable gate at a time: deterministic route reservations, assignment-based runtime state, per-worker lease and settlement isolation, storage contention, then host/reconnect coverage. Concurrent hiring remains disabled until every runtime gate passes; the existing real host/farmhand and final visual acceptance procedures remain deferred until the maintainer schedules them.
+Debris clearing, planting, fertilizing, automatic machine refilling, automatic shipping, special/modded storage, and destructive outside-farm obstacle escalation remain outside the current release sequence and require separate design issues.

--- a/docs/RELEASE_NOTES_0.3.2.md
+++ b/docs/RELEASE_NOTES_0.3.2.md
@@ -1,0 +1,47 @@
+# Evil Farm Owner v0.3.2
+
+## 中文
+
+v0.3.2 集中解决单工人班次中的路线中断与诊断问题，不加入多工人或新的存档格式。
+
+### 路线可靠性
+
+- 收获、浇水、动物照料和箱子整理现在使用同一套中断分类：超时、像素进度停滞、控制器提前结束或被替换、第一步碰撞和控制器创建失败。
+- 每次中断会记录地图、NPC 格子与像素坐标、目的地、下一路径点、剩余路径、控制器归属和实时碰撞结果。
+- 动态障碍按地图记录为格子或有向路径边；每个路线阶段最多尝试三次，不会反复撞向同一段路线。
+- 农场内始终使用非破坏寻路并允许打开门。单个作物、动物或建筑入口失败时只跳过对应目标；棚舍出口或返程失败时安全停止并恢复 NPC。
+- 箱子整理在移动阶段不会取出源物品；锁内转移若异常，必须完整回滚或写入持久恢复区后才能结束。
+
+### 可验证的开发检查
+
+- 与游戏程序集无关的规划、工资、存储守恒、协议和路线决策代码已进入独立的 .NET 8 Core 项目。
+- GitHub Actions 会在 Ubuntu 上编译 Core 并运行全部 122 项确定性测试；完整 Mod 编译和发布包检查仍由本地干净发布验证器负责。
+
+### 兼容与限制
+
+- 不修改多人协议、存档结构、配置格式或单工人上限。
+- 真实双进程多人验收仍是 v0.5.0 的发布门槛，本版本不声称已完整验证远程多人游戏。
+- 需要 Stardew Valley 1.6+、SMAPI 4.0+；Generic Mod Config Menu 仍为可选依赖。
+
+## English
+
+v0.3.2 focuses on interrupted-route recovery and diagnostics for single-worker shifts. It does not add concurrent workers or a new save format.
+
+### Route reliability
+
+- Harvesting, watering, animal care, and chest sorting now share the same interruption classes: timeout, pixel-progress stall, early or replaced controller, rejected first step, and controller setup failure.
+- Every interruption records the map, NPC tile and pixel position, destination, next and remaining waypoints, controller ownership, and a live collision probe.
+- Dynamic obstacles are stored per location as tiles or directed edges. Each route stage gets at most three attempts and cannot keep retrying the same failed segment.
+- Farm movement stays non-destructive and can open gates. An isolated crop, animal, or building entrance is skipped; an exhausted shed exit or return route stops safely and restores the NPC.
+- Chest sorting never removes a source item during travel. A locked-transfer failure must fully roll back or enter durable recovery before finalization.
+
+### Verifiable development checks
+
+- Game-independent planning, wage, storage-conservation, protocol, and route-decision source now lives in a standalone .NET 8 Core project.
+- GitHub Actions compiles Core and runs all 122 deterministic tests on Ubuntu. The clean local release verifier remains responsible for the proprietary-game Mod build and package checks.
+
+### Compatibility and limits
+
+- No multiplayer protocol, save-schema, configuration-format, or one-worker-limit changes.
+- Real two-process multiplayer acceptance remains a v0.5.0 release gate; this release does not claim complete remote-multiplayer verification.
+- Requires Stardew Valley 1.6+ and SMAPI 4.0+. Generic Mod Config Menu remains optional.

--- a/docs/RELEASE_NOTES_0.3.2.md
+++ b/docs/RELEASE_NOTES_0.3.2.md
@@ -15,7 +15,7 @@ v0.3.2 集中解决单工人班次中的路线中断与诊断问题，不加入�
 ### 可验证的开发检查
 
 - 与游戏程序集无关的规划、工资、存储守恒、协议和路线决策代码已进入独立的 .NET 8 Core 项目。
-- GitHub Actions 会在 Ubuntu 上编译 Core 并运行全部 122 项确定性测试；完整 Mod 编译和发布包检查仍由本地干净发布验证器负责。
+- GitHub Actions 会在 Ubuntu 上编译 Core 并运行全部 122 项确定性测试；本地干净发布验证器也会先检查 Core 边界和编译结果，再执行完整 Mod 编译与发布包检查。
 
 ### 兼容与限制
 
@@ -38,7 +38,7 @@ v0.3.2 focuses on interrupted-route recovery and diagnostics for single-worker s
 ### Verifiable development checks
 
 - Game-independent planning, wage, storage-conservation, protocol, and route-decision source now lives in a standalone .NET 8 Core project.
-- GitHub Actions compiles Core and runs all 122 deterministic tests on Ubuntu. The clean local release verifier remains responsible for the proprietary-game Mod build and package checks.
+- GitHub Actions compiles Core and runs all 122 deterministic tests on Ubuntu. The clean local release verifier repeats the Core boundary/build gate before the proprietary-game Mod build and package checks.
 
 ### Compatibility and limits
 

--- a/docs/ROUTE_ACCEPTANCE.md
+++ b/docs/ROUTE_ACCEPTANCE.md
@@ -1,0 +1,34 @@
+# Single-worker Route Acceptance
+
+Run this gate in a disposable single-player save with the exact production candidate. Do not use an acceptance-fault DLL for this matrix. Record the Mod DLL SHA-256, game/SMAPI versions, save date, worker, result, final HUD reason, and relevant Debug/Warn log lines for every row.
+
+## Invariants for every scenario
+
+- The worker uses a genuine farm-boundary entrance, never the farmhouse or cave.
+- Chests, machines, fences, gates, decorations, crops, and terrain are not destroyed or displaced.
+- Opening a gate is allowed; leaving it in an invalid state is not.
+- One hire produces one reservation and one final settlement. A retry never charges again.
+- Every captured or detached item reconciles exactly to requester inventory, a classified chest, overflow, visible drop, quarantine, or an unresolved recovery record.
+- Each retry writes a Debug interruption snapshot. The final exhausted route writes Warn and a concise localized HUD reason.
+
+## Route matrix
+
+| Scenario | Setup and action | Pass condition |
+| --- | --- | --- |
+| Farm obstacle | Put a movable obstacle on the active route after dispatch. | The worker excludes the failed tile or directed edge, replans within three attempts, and preserves the obstacle. |
+| Narrow entrance | Fence a one-tile corridor with a closed gate on the viable approach. | The NPC opens the gate and passes without destructive pathing or an entrance loop. |
+| Dense and trellis crops | Mix ordinary crops with hops or grapes and leave multiple dry and mature targets behind them. | All reachable targets use cardinal interaction edges; only truly isolated targets are skipped. |
+| Harvest delivery | Provide exact-stack, same-item, same-category, and empty fallback chests, then obstruct the selected delivery path. | Classification stays deterministic, cargo reaches the selected compatible chest after replanning, or enters lossless recovery after exhaustion. |
+| Animal-house door | Obstruct barn/coop approach, indoor animal routes, and the return to the human door one at a time. | A failed animal/building is isolated; an exhausted exit safely stops and restores the worker. |
+| Chest sorting | Obstruct source, destination, and return paths in separate runs. | Pre-transfer failure leaves the source untouched; post-detach failure rolls back or persists recovery before return. |
+| Player changes map | Leave the farm while each stage is moving and acting. | Host execution continues on the farm and settles once without depending on the requester camera or location. |
+| Dynamic return obstacle | Block the route to the arrival tile after the last action. | The worker replans up to three times; final failure restores safely and reports the actual interruption class. |
+
+## Evidence summary
+
+The matrix is complete only when every row has recorded evidence and both checks below pass:
+
+1. Before/after world and item counts reconcile with no placed-object mutation.
+2. The SMAPI log contains no Evil Farm Owner error or unhandled exception.
+
+Real host/farmhand two-process acceptance is intentionally separate and remains a v0.5.0 gate in `MULTIPLAYER_TEST_PLAN.md`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Evil Farm Owner",
   "Author": "Aveouter",
-  "Version": "0.3.1",
+  "Version": "0.3.2",
   "Description": "Hire available adult NPCs for complete visible farm-work shifts with safe harvest delivery.",
   "UniqueID": "Aveouter.EvilFarmOwner",
   "EntryDll": "EvilFarmOwner.dll",

--- a/scripts/verify-release-asset.sh
+++ b/scripts/verify-release-asset.sh
@@ -71,7 +71,7 @@ dll_search_text="$(
   unzip -p "$asset_path" EvilFarmOwner/EvilFarmOwner.dll \
     | LC_ALL=C tr -d '\000'
 )"
-if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_faults|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
+if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
   echo "Downloaded DLL exposes a legacy prototype or acceptance-test command/setting." >&2
   exit 1
 fi

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -79,7 +79,7 @@ if ! cmp -s LICENSE <(unzip -p "$package_path" EvilFarmOwner/LICENSE); then
 fi
 
 dll_search_text="$(LC_ALL=C tr -d '\000' < "$project_root/bin/Release/net6.0/EvilFarmOwner.dll")"
-if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_faults|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
+if [[ "$dll_search_text" =~ efo_work|efo_toggle|efo_status|efo_acceptance_|WorkRadius|DailyWage|ClearDebris|PlantSeedsFromInventory|FertilizeEmptyDirt ]]; then
   echo "Release DLL still exposes a legacy prototype or acceptance-test command/setting." >&2
   exit 1
 fi

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -31,6 +31,11 @@ fi
 echo "Source commit: $source_commit"
 echo "Source tree: $source_tree"
 
+"$project_root/scripts/verify-core-boundary.sh"
+
+dotnet build EvilFarmOwner.Core.csproj \
+  -c Release
+
 dotnet run \
   -c Release \
   --project tests/EvilFarmOwner.LogicTests.csproj \

--- a/src/ModEntry.cs
+++ b/src/ModEntry.cs
@@ -5,6 +5,7 @@ using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Network;
 using StardewValley.Objects;
+using System.Reflection;
 
 namespace EvilFarmOwner;
 
@@ -103,6 +104,10 @@ public sealed class ModEntry : Mod
             "efo_acceptance_faults",
             "Arm test-only harvest storage failures. This command is excluded from production builds.",
             this.HandleAcceptanceFaultCommand);
+        helper.ConsoleCommands.Add(
+            "efo_acceptance_click",
+            "Click the active game menu at test coordinates. This command is excluded from production builds.",
+            this.HandleAcceptanceClickCommand);
         this.Monitor.Log(
             "ACCEPTANCE TEST BUILD: harvest storage fault injection is enabled. Do not distribute this DLL.",
             LogLevel.Alert);
@@ -110,6 +115,48 @@ public sealed class ModEntry : Mod
     }
 
 #if EFO_ACCEPTANCE_FAULTS
+    private void HandleAcceptanceClickCommand(string command, string[] args)
+    {
+        if (args.Length == 1 && string.Equals(args[0], "status", StringComparison.OrdinalIgnoreCase))
+        {
+            if (Game1.activeClickableMenu is not IClickableMenu activeMenu)
+            {
+                this.Monitor.Log("Acceptance menu status requires an active game menu.", LogLevel.Warn);
+                return;
+            }
+
+            IEnumerable<string> components = activeMenu.GetType()
+                .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(field => typeof(ClickableComponent).IsAssignableFrom(field.FieldType))
+                .Select(field => (field.Name, Component: field.GetValue(activeMenu) as ClickableComponent))
+                .Where(value => value.Component is not null)
+                .Select(value => $"{value.Name}={value.Component!.bounds}");
+            this.Monitor.Log(
+                $"Acceptance menu {activeMenu.GetType().Name}: bounds=({activeMenu.xPositionOnScreen},{activeMenu.yPositionOnScreen},{activeMenu.width},{activeMenu.height}); components=[{string.Join("; ", components)}].",
+                LogLevel.Info);
+            return;
+        }
+
+        if (args.Length != 2
+            || !int.TryParse(args[0], out int x)
+            || !int.TryParse(args[1], out int y))
+        {
+            this.Monitor.Log("Usage: efo_acceptance_click status | <x> <y>", LogLevel.Info);
+            return;
+        }
+
+        if (Game1.activeClickableMenu is not IClickableMenu menu)
+        {
+            this.Monitor.Log("Acceptance menu click requires an active game menu.", LogLevel.Warn);
+            return;
+        }
+
+        menu.receiveLeftClick(x, y);
+        this.Monitor.Log(
+            $"Acceptance menu click invoked {menu.GetType().Name}.receiveLeftClick({x}, {y}).",
+            LogLevel.Debug);
+    }
+
     private void HandleAcceptanceFaultCommand(string command, string[] args)
     {
         if (args.Length == 0 || string.Equals(args[0], "status", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Closes #135

## Included
- align project, manifest, README, changelog, and bilingual release notes on 0.3.2
- replace the obsolete v0.1-era project plan with the actual v0.3.2 → v0.5.0 release order
- add the disposable-save single-worker route acceptance matrix and explicit evidence invariants
- retain the honest limitation that real two-process multiplayer is deferred to v0.5.0

## Automated candidate checks completed
- non-deploying Release build: 0 warnings, 0 errors
- deterministic tests: 122/122 passed
- package allowlist, production command scan, JSON/version/translation checks passed

## Required before ready/merge
- [ ] v0.3.1 exact downloaded ZIP SMAPI smoke and public release
- [ ] route matrix evidence recorded
- [ ] forced storage-fault matrix evidence recorded
- [ ] remove only the README limitations that the evidence actually closes
- [ ] clean verifier from the final reviewed commit
- [ ] exact ZIP re-download audit and SMAPI load smoke

No multiplayer protocol or save-format change is included.