### PR TITLE
ci(actions): move setup-dotnet to Node 24 runtime

### DIFF
--- a/.github/workflows/source-validation.yml
+++ b/.github/workflows/source-validation.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: 8.0.x
 


### PR DESCRIPTION
Closes #144.

## 变更概述

将 Source validation 工作流固定到官方 `actions/setup-dotnet` v5 提交，使动作原生使用 Node.js 24。

## 修改动机

当前工作流虽然成功，但 GitHub 已标记 setup-dotnet v4 使用的 Node.js 20 运行时为弃用，并由运行器临时强制转换。升级可以消除该警告并避免未来运行器停止兼容。

## 主要改动

- 仅修改 `.github/workflows/source-validation.yml`。
- 将 setup-dotnet 从固定的 v4 SHA 替换为官方 v5 tag 当前提交 `26b0ec14cb23fa6904739307f278c14f94c95bf1`。
- 保持 .NET 8、源码校验、Core 编译和确定性测试命令不变。

## 实验与验证

- 已运行 `git diff --check`。
- 合并前由本 PR 的 Source validation 在精确头提交上运行一次，并检查 Node.js 20 弃用 annotation 已消失。

## 对 Benchmark / Baseline 的影响

- 数据集：无。
- 评测协议：无。
- 指标定义：无。
- Baseline：无。
- 结果可复现性：测试命令与 .NET 版本均未改变，仅升级 GitHub Action 的执行运行时。

## 风险与限制

- 仅影响托管 CI 的 setup-dotnet 动作。
- 不修改 Mod 代码、游戏行为、协议、发布包或本机发布验证。