### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.0 - 2026-08-27
+
+- Added host-configurable concurrent hiring for one to four available adult NPCs while preserving a one-worker default and legacy configuration migration.
+- Added multi-select hiring and stable budget-aware automatic selection using efficiency, friendship-adjusted wage, friendship, and NPC name.
+- Let all selected workers share harvest and watering targets through unique host-owned claims, while animal care and chest sorting remain single-owner stages.
+- Added map-scoped tile, edge, entrance, and indoor route reservations so workers wait or replan without crossing through each other or destroying farm objects.
+- Added independent NPC leases, cargo, recovery, and wage settlements with one bounded failed-stage reassignment and no duplicate charge.
+- Upgraded multiplayer synchronization to schema 11 with per-worker snapshots, atomic batch validation, idempotent reconnect requests, host-restart history recovery, and schema-10 single-worker migration.
+- Added a one-pass multiplayer evidence collector for peer DLL hashes, final network agreement, recovery health, and SMAPI error scanning.
+- Recorded the maintainer decision to publish without the live 1–4 worker matrix, save/reload and reconnect scenarios, real two-process multiplayer run, or final in-game ZIP smoke test; those scenarios remain unverified.
+
 ## 0.3.2 - 2026-08-26
 
 - Added a shared primitive-only travel interruption snapshot and map-scoped tile/edge obstacle ledger for bounded route recovery across farm-work controllers.

--- a/EvilFarmOwner.csproj
+++ b/EvilFarmOwner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.3.2</Version>
+    <Version>0.5.0</Version>
     <AssemblyName>EvilFarmOwner</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Aveouter/EvilFarmOwner</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </h1>
 
 <p align="center">
-  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.3.2
+  <strong>邪恶农场主</strong> · Stardew Valley SMAPI Mod · v0.5.0
 </p>
 
 <p align="center">
@@ -39,7 +39,7 @@
 2. 从 [Releases](https://github.com/Aveouter/EvilFarmOwner/releases/latest) 下载 ZIP。
 3. 解压后，把 `EvilFarmOwner` 文件夹放进游戏的 `Mods` 文件夹。
 4. 通过 SMAPI 启动游戏，载入存档并站在主农场。
-5. 按 `K`，选择一名工人，确认工资和产物去向，然后开始班次。
+5. 按 `K`，选择工人，确认总工资和产物去向，然后开始班次。默认上限为 1 人，主机可在设置中提高到 4 人。
 
 需要 Stardew Valley 1.6 或更高版本。Generic Mod Config Menu 是可选的，可用于修改按键、工资和综合班次偏好。
 
@@ -57,7 +57,7 @@
 
 使用分类箱时，NPC 会连续收集产物，按照原版可堆叠规则模拟携带空间，达到 12 个实际物品格后再集中送货；同物品同品质会共用一格，而不是每件作物各占一格。送货时按目标箱分组，每个箱子只走访和加锁一次；目标已经采完或接近停止采集时间时也会立即送货。玩家背包模式仍即时交付，因为它不需要 NPC 往返。
 
-玩家离开农场后，NPC 仍会在农场继续工作。当前同一时间只能执行一份合同、雇佣一名工人。
+玩家离开农场后，NPC 仍会在农场继续工作。同一时间只执行一份合同，但一份合同可以包含 1–4 名工人。多人班次会让所有工人分担收获和浇水；动物照料与箱子整理各只交给一人，避免重复操作。
 
 ### 工资
 
@@ -67,7 +67,7 @@
 - 休息日需要明确授权三倍工资。
 - 开工时暂时预留最高工资，工人返回后按实际工时收费并退回剩余金币。
 
-安装可选的 Generic Mod Config Menu 后，主机可以调整基础时薪（50g–500g）、好感度影响（0%–40%）、休息日倍率（1.0–5.0 倍）、默认产物去向，并启用或关闭收获、浇水、动物照料和箱子整理。至少保留一个工作阶段；已经开工的班次不会被中途修改。
+安装可选的 Generic Mod Config Menu 后，主机可以调整基础时薪（50g–500g）、好感度影响（0%–40%）、休息日倍率（1.0–5.0 倍）、同时雇佣上限（1–4 人）、默认产物去向，并启用或关闭收获、浇水、动物照料和箱子整理。至少保留一个工作阶段；已经开工的班次不会被中途修改。
 
 ### 收获物去向
 
@@ -87,13 +87,15 @@
 - 普通日工资上限；
 - 是否允许休息日三倍工资。
 
-授权从下一个游戏日开始。主机在上午 6:10 到下午 4:00 之间进入主农场时，Mod 每天最多尝试一次。自动合同与手动雇佣执行同一套完整班次；NPC、预算、路线或储存条件不合适时会跳过当天。
+授权从下一个游戏日开始。主机在上午 6:10 到下午 4:00 之间进入主农场时，Mod 每天最多尝试一次。自动合同会在授权名单中按工作效率、工资、好感度和姓名稳定选择最多 4 名合适工人，并与手动雇佣执行同一套完整班次；NPC、预算、路线或储存条件不合适时会跳过当天。
 
 ### 多人游戏
 
 主机和农场工都可以申请合同，但只有主机修改金币、NPC、作物、动物和箱子。所有玩家必须安装完全相同的 Mod 版本。
 
-协议包含重复请求防护、阶段同步、断线重连和主机重启后的历史结果恢复。真实双进程多人验收仍未完成，重要存档请先备份；报告联机问题时请同时提供主机与农场工的 SMAPI 日志。
+协议包含重复请求防护、每名工人的状态同步、断线重连和主机重启后的历史结果恢复。多人班次的任务认领、路线等待、货物和工资都分别记录，单个工人失败不会重复收取其他人的工资。
+
+维护者选择在未执行真实双进程和完整实机矩阵的情况下发布本版本，因此这些场景仍属于未验证状态。重要存档请先备份；报告联机问题时请同时提供主机与农场工的 SMAPI 日志。
 
 ### 常用命令
 
@@ -115,9 +117,8 @@ efo_netstatus    查看联机合同状态
 - 暂不支持清理杂物、播种、施肥、自动补充机器原料或自动出售。
 - 不接管动物自动采集器；也不收取会在交互时重新计算产物或自动续产的机器。
 - 仅支持主农场上的普通玩家箱子，不支持特殊箱子和其他 Mod 添加的箱子。
-- 当前一次只能雇佣一名工人；多人调度、路线预留和工资汇总仍在逐步接入，尚未开放并发。
 - 自定义农场如果没有安全路线，合同会拒绝开始或提前停止。
-- 强制储存故障矩阵、真实双进程多人和最终发布 ZIP 的游戏内烟雾测试尚未完整执行。
+- 2–4 人实机矩阵、强制储存故障矩阵、真实双进程多人和最终发布 ZIP 的游戏内烟雾测试未执行；本版本基于自动测试直接验收。
 
 ---
 
@@ -135,7 +136,7 @@ NPCs who are busy with festivals, events, work schedules, or other protected act
 2. Download the ZIP from [Releases](https://github.com/Aveouter/EvilFarmOwner/releases/latest).
 3. Extract it and place the `EvilFarmOwner` folder in your game's `Mods` folder.
 4. Launch through SMAPI, load a save, and stand on the main farm.
-5. Press `K`, choose a worker, review the wage and delivery destination, then confirm.
+5. Press `K`, select workers, review the combined wage and delivery destination, then confirm. The default limit is one; the host may raise it to four in settings.
 
 Stardew Valley 1.6 or later is required. Generic Mod Config Menu is optional and exposes the hotkey, wage, and complete-shift preferences.
 
@@ -153,7 +154,7 @@ Empty stages are skipped. The worker replans or skips isolated unreachable targe
 
 With classified chests selected, the NPC simulates vanilla-compatible stacking and keeps collecting until the cargo occupies 12 actual slots; compatible items share a slot instead of every crop counting separately. Delivery then groups cargo by destination so each chest is visited and locked once. Cargo is also delivered when no target remains or the acquisition cutoff is reached. Requester-inventory delivery remains immediate because it requires no NPC round trip.
 
-The NPC continues working on the farm when the player changes maps. Only one contract and one worker can run at a time in the current version.
+NPCs continue working on the farm when the player changes maps. Only one contract runs at a time, but that contract may include one to four workers. All workers can share harvesting and watering; animal care and chest sorting each have one owner to prevent duplicate actions.
 
 ### Wages
 
@@ -163,7 +164,7 @@ The NPC continues working on the farm when the player changes maps. Only one con
 - Rest-day work requires explicit authorization for triple pay.
 - The maximum is reserved at dispatch, then unused gold is refunded after the worker returns.
 
-With the optional Generic Mod Config Menu installed, the host can adjust the base rate (50g–500g), friendship impact (0%–40%), rest-day multiplier (1.0x–5.0x), default harvest destination, and which of harvesting, watering, animal care, and chest sorting are included. At least one stage remains enabled, and a running shift keeps its starting snapshot.
+With the optional Generic Mod Config Menu installed, the host can adjust the base rate (50g–500g), friendship impact (0%–40%), rest-day multiplier (1.0x–5.0x), simultaneous-worker limit (1–4), default harvest destination, and which of harvesting, watering, animal care, and chest sorting are included. At least one stage remains enabled, and a running shift keeps its starting snapshot.
 
 ### Harvest delivery
 
@@ -178,13 +179,15 @@ A running contract never changes destination silently. If the selected destinati
 
 The host can open “Automatic contract” from the bottom of the roster and choose a preferred worker, an explicit substitute pool, a regular-day wage cap, and whether rest-day triple pay is allowed.
 
-Starting the next game day, the mod tries at most once when the host enters the main farm between 6:10 AM and 4:00 PM. Automatic hiring uses the same complete shift as manual hiring and skips the day when worker, budget, route, or storage checks fail.
+Starting the next game day, the mod tries at most once when the host enters the main farm between 6:10 AM and 4:00 PM. It selects up to four authorized workers in a stable efficiency, wage, friendship, and name order. Automatic hiring uses the same complete shift as manual hiring and skips the day when worker, budget, route, or storage checks fail.
 
 ### Multiplayer
 
 Hosts and farmhands may request contracts, but only the host changes money, NPCs, crops, animals, and storage. Every player must install the exact same mod version.
 
-The protocol includes duplicate-request protection, phase synchronization, reconnect handling, and prior-result recovery after a host restart. Real two-process acceptance is still incomplete, so back up important saves and include both host and farmhand SMAPI logs in multiplayer reports.
+The protocol includes duplicate-request protection, per-worker state synchronization, reconnect handling, and prior-result recovery after a host restart. Multi-worker targets, route waits, cargo, and billing are tracked independently so one worker's failure does not charge the others twice.
+
+The maintainer chose to publish without a real two-process run or the full live matrix, so those scenarios remain unverified. Back up important saves and include both host and farmhand SMAPI logs in multiplayer reports.
 
 ### Useful commands
 
@@ -206,9 +209,8 @@ If an old `H` hotkey conflicts with UI Info Suite 2, change it to `K` through Ge
 - No debris clearing, planting, fertilizing, automatic machine refilling, or automatic shipping.
 - Auto-grabbers and machines which recalculate or automatically restart on collection are excluded.
 - Only ordinary player-owned main-farm chests are supported; special and modded chests are excluded.
-- Only one worker can be hired at a time. Multi-worker scheduling, route reservations, and aggregate billing are being integrated but concurrent dispatch is not enabled.
 - A custom farm without a safe route may reject or stop a contract.
-- The forced-storage fault matrix, real two-process multiplayer, and final in-game smoke test of the published ZIP are not yet complete.
+- The live 2–4 worker matrix, forced-storage fault matrix, real two-process multiplayer run, and final in-game smoke test of the published ZIP were not performed; this version was accepted from automated evidence.
 
 ## Compatibility
 

--- a/docs/HIRING_UI_SPEC.md
+++ b/docs/HIRING_UI_SPEC.md
@@ -1,6 +1,6 @@
 # Hiring UI layout specification
 
-This specification describes the hiring flow implemented on the draft v0.5.0 branch. The current public release still defaults to one worker; the host may raise the draft setting to four after the live release gates pass.
+This specification describes the v0.5.0 hiring flow. The public default remains one worker, and the host may raise the simultaneous-worker setting to four.
 
 ## Shared layout
 

--- a/docs/MULTI_WORKER_ARCHITECTURE.md
+++ b/docs/MULTI_WORKER_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Multi-worker architecture boundary
 
-This document describes the concurrent worker runtime implemented on the draft v0.5.0 branch. It is not a claim that v0.5.0 has passed its live multiplayer release gates.
+This document describes the concurrent worker runtime released in v0.5.0. It is not a claim that the waived live multiplayer matrix passed.
 
 ## Host-owned shift snapshot
 

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -11,12 +11,13 @@ Every implementation starts from an issue with one `type`, `priority`, `area`, a
 - `v0.3.0` provides complete single-worker shifts, configurable wages and stages, batched lossless harvest delivery, animal care, chest sorting, and host-authoritative protocol 9 behavior.
 - `v0.3.1` is the narrow harvest-delivery hotfix: vanilla-compatible 12-slot accounting plus detailed classified-chest delivery recovery.
 - `v0.3.2` unifies route interruption diagnostics and bounded non-destructive replanning, and moves deterministic logic tests into the standalone .NET 8 Core project used by CI.
+- `v0.5.0` adds opt-in concurrent hiring for up to four workers, host-owned target and route coordination, independent settlement/recovery, and protocol schema 11.
 
-## Current development: v0.5.0 - Concurrent workers
+## Released scope: v0.5.0 - Concurrent workers
 
 Concurrent execution remains opt-in: the host-owned `MaximumConcurrentWorkers` setting accepts 1–4 and defaults to 1. A shift keeps an immutable settings snapshot, and old single-worker settings migrate to the default limit of one.
 
-Implemented on the draft feature branch:
+Implemented in the release:
 
 - manual selection and stable budget-aware automatic selection for up to four available adult NPCs;
 - host validation, immutable settings synchronization, protocol migration, and per-worker reconnect snapshots;
@@ -31,7 +32,7 @@ Automated acceptance evidence:
 
 - the standalone Core suite already records deterministic selection, partition, claims, route conflicts, one-worker route equivalence, settlement aggregation, protocol migration, restart recovery data, and reconnect serialization;
 - the production Mod builds without warnings or errors, and the current Source validation workflow passes;
-- the release verifier, package allowlist, production-command scan, and SHA-256 audit remain required when the v0.5.0 release package is produced.
+- the release verifier, package allowlist, production-command scan, and SHA-256 audit are required for the published v0.5.0 package.
 
 Maintainer acceptance decision (2026-08-27): the live 1–4 worker matrix, save/reload and reconnect scenarios, real two-process host/farmhand run, and exact-ZIP SMAPI smoke test were explicitly waived for merge without being performed. This is risk acceptance, not evidence that those scenarios passed. User-facing release notes must identify remote multiplayer and live multiworker behavior as unverified until a future recorded run supplies that evidence.
 

--- a/docs/RELEASE_NOTES_0.5.0.md
+++ b/docs/RELEASE_NOTES_0.5.0.md
@@ -1,0 +1,51 @@
+# Evil Farm Owner v0.5.0
+
+## 中文
+
+v0.5.0 开放多人同时雇佣。默认仍然一次雇佣 1 人，主机可以在 Generic Mod Config Menu 中把上限调整为 2–4 人。
+
+### 主要变化
+
+- 名单支持多选，并显示合计的最高授权工资；自动选择会综合工作效率、工资、好感度和姓名，结果稳定且不超预算。
+- 所有工人都可以分担收获和浇水，同一个目标只会被一人领取。动物照料和箱子整理各由一人负责，避免重复操作。
+- 工人会为同一格、相向路线、农场入口、畜棚入口和箱子访问进行等待或重新规划，不会为了通行摧毁农场摆设。
+- 每名工人拥有独立的 NPC 状态、货物和工资结算。某人失败时，只会进行一次有限的任务转交，不会让其他工人重复付费。
+- 联机协议升级为 schema 11，支持每名工人的状态、原请求 ID 重连、主机重启后的历史结果，以及旧单工人配置迁移。
+
+### 安装
+
+需要 Stardew Valley 1.6+ 与 SMAPI 4.0+。下载 ZIP，解压后把 `EvilFarmOwner` 文件夹放入游戏的 `Mods` 文件夹。联机双方必须安装完全相同的版本。
+
+Generic Mod Config Menu 仍为可选依赖。并发上限默认为 1，只有主机设置会控制合同。
+
+### 已知限制与验收说明
+
+- 维护者明确选择不执行 1–4 人完整实机矩阵、保存/重载、断线重连、真实双进程多人和最终发布 ZIP 的游戏内烟雾测试，直接基于自动证据验收。本说明表示风险已被接受，不表示这些场景已经通过。
+- 自动证据包括 132 项确定性逻辑测试、无警告/错误的生产构建、源码边界检查、包内容白名单、生产命令扫描和 SHA-256 审计。
+- 重要联机存档请先备份；反馈问题时请同时附上主机和农场工的完整 SMAPI 日志。
+- 仍不支持清理杂物、播种、施肥、自动补充机器原料、自动出售、特殊箱子或其他 Mod 添加的储存容器。
+
+## English
+
+v0.5.0 enables concurrent hiring. The default remains one worker per contract, and the host can raise the limit to two, three, or four through Generic Mod Config Menu.
+
+### Highlights
+
+- The roster supports multi-selection and shows one combined maximum authorization. Automatic selection uses stable efficiency, wage, friendship, and name ordering without exceeding the budget.
+- Every worker may share harvesting and watering, with one owner per target. Animal care and chest sorting each retain a single owner to prevent duplicate actions.
+- Workers wait or replan around same-tile, opposing-edge, farm-entrance, building-entrance, and chest-access conflicts without destroying placed farm objects.
+- Each worker has independent NPC state, cargo, and wage settlement. One failed worker permits one bounded reassignment without charging another worker twice.
+- Multiplayer protocol schema 11 synchronizes each worker, retains the original request ID across reconnects, restores prior results after a host restart, and migrates legacy single-worker settings.
+
+### Installation
+
+Stardew Valley 1.6+ and SMAPI 4.0+ are required. Download and extract the ZIP, then place the `EvilFarmOwner` folder in the game's `Mods` directory. Every multiplayer peer must install this exact version.
+
+Generic Mod Config Menu remains optional. The concurrent-worker limit defaults to one, and only the host's settings control contracts.
+
+### Known limitations and acceptance notice
+
+- The maintainer explicitly waived the full live 1–4 worker matrix, save/reload, reconnect, real two-process multiplayer, and final in-game smoke test of the published ZIP, accepting the release from automated evidence. This records accepted risk; it does not claim those scenarios passed.
+- Automated evidence includes 132 deterministic logic tests, a warning/error-free production build, Core boundary checks, the package allowlist, production-command scan, and SHA-256 audit.
+- Back up important multiplayer saves and attach both complete SMAPI logs when reporting a problem.
+- Debris clearing, planting, fertilizing, automatic machine input, automatic shipping, special chests, and modded storage are still unsupported.

--- a/docs/ROUTE_ACCEPTANCE.md
+++ b/docs/ROUTE_ACCEPTANCE.md
@@ -31,4 +31,4 @@ The matrix is complete only when every row has recorded evidence and both checks
 1. Before/after world and item counts reconcile with no placed-object mutation.
 2. The SMAPI log contains no Evil Farm Owner error or unhandled exception.
 
-Real host/farmhand two-process acceptance is intentionally separate and remains a v0.5.0 gate in `MULTIPLAYER_TEST_PLAN.md`.
+Real host/farmhand two-process acceptance remains the deferred procedure in `MULTIPLAYER_TEST_PLAN.md`; it was explicitly waived for the initial v0.5.0 release.

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "Name": "Evil Farm Owner",
   "Author": "Aveouter",
-  "Version": "0.3.2",
-  "Description": "Hire available adult NPCs for complete visible farm-work shifts with safe harvest delivery.",
+  "Version": "0.5.0",
+  "Description": "Hire up to four available adult NPCs for safe, complete farm-work shifts.",
   "UniqueID": "Aveouter.EvilFarmOwner",
   "EntryDll": "EvilFarmOwner.dll",
   "MinimumApiVersion": "4.0.0",


### PR DESCRIPTION
## 变更概述

准备 Evil Farm Owner v0.5.0 正式发布，统一版本号、用户 README、变更日志、双语发布说明和项目状态文档。

## 修改动机

多工人运行时与配套恢复、结算和诊断能力已经合并，需要提供面向用户的一致版本说明与可审计发布候选。

## 主要改动

- 将项目与 manifest 版本设置为 0.5.0。
- 重写 README 的快速开始、多工人行为、设置和限制说明。
- 添加 v0.5.0 中英文发布说明和 CHANGELOG 条目。
- 将雇佣 UI、多工人架构、路线验收与项目计划同步为实际发布状态。
- 明确记录维护者已接受跳过本次实机、多进程和完整现场矩阵验收的风险，不将其描述为已通过。

## 实验与验证

- scripts/verify-release.sh：通过。
- 确定性逻辑测试：132/132 通过。
- Release 构建：0 个警告，0 个错误。
- Core 边界、包内容白名单、生产 DLL 命令扫描：通过。
- GitHub Source validation：通过（run 32989591074）。
- 源码树：17993c7531b0535bb6749ee1b2562c8b44ce86b9。
- ZIP SHA-256：5e69ad7316dacd11587f3ac1058e9d21e8e3dff687a35fffa3e02b680ceeeecb。

按维护者明确要求未启动 Stardew Valley。

## 对 Benchmark / Baseline 的影响

- 数据集：无影响。
- 评测协议：不更改现有逻辑测试定义。
- 指标定义：无影响。
- Baseline：发布基线从 v0.3.2 更新为 v0.5.0。
- 结果可复现性：通过固定发布候选树、自动化验证和资产 SHA-256 提供追溯。

## 风险与限制

未执行 2–4 工人完整实机矩阵、真实双进程多人、强制存储故障和最终 ZIP 游戏内启动检查。这些项目是维护者明确接受的发布风险，并在 README、项目计划和发布说明中公开披露。

Tracks #146