### PR TITLE
chore(agents): configure engineering skill workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Instructions
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `Aveouter/EvilFarmOwner`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the repo's `status:*` label vocabulary, with `wontfix` reused for rejected work. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repo. Read root `CONTEXT.md` when present and relevant ADRs under `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,29 @@
+# Domain Docs
+
+This repo uses a single-context domain documentation layout.
+
+## Before Exploring
+
+When working on a code change, read these files if they exist and are relevant:
+
+- `CONTEXT.md` at the repo root for project vocabulary and domain rules.
+- `docs/adr/` for architecture decisions that touch the area being changed.
+
+If these files do not exist, proceed with the repository's existing docs and code. Do not invent missing decisions.
+
+## Layout
+
+```text
+/
+|-- CONTEXT.md
+|-- docs/
+|   |-- adr/
+|   `-- agents/
+`-- src/
+```
+
+## Usage Rules
+
+Use terms from `CONTEXT.md` in issue titles, PR descriptions, tests, and code names when those terms exist.
+
+If a proposed change contradicts an ADR, call that out explicitly before implementing.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,21 @@
+# Issue Tracker: GitHub
+
+Issues, implementation tickets, and PRDs for this repo live in GitHub Issues on `Aveouter/EvilFarmOwner`.
+
+Use the `gh` CLI for issue operations from inside this repository. The repository is inferred from `git remote -v`.
+
+## Conventions
+
+- Create an issue with `gh issue create --title "..." --body "..."`.
+- Read an issue with `gh issue view <number> --comments`.
+- List issues with `gh issue list --state open --json number,title,body,labels,comments`.
+- Comment on an issue with `gh issue comment <number> --body "..."`.
+- Apply labels with `gh issue edit <number> --add-label "..."`.
+- Remove labels with `gh issue edit <number> --remove-label "..."`.
+- Close issues with `gh issue close <number> --comment "..."`.
+
+## Skill Routing
+
+When a skill says "publish to the issue tracker", create a GitHub issue.
+
+When a skill says "fetch the relevant ticket", read the GitHub issue and comments.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,20 @@
+# Triage Labels
+
+The engineering skills use five canonical triage roles. This file maps those roles to the labels configured in GitHub Issues.
+
+| Skill role | Repo label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `status:needs-triage` | Maintainer needs to evaluate the issue. |
+| `needs-info` | `status:needs-info` | Waiting on the reporter or user for missing details. |
+| `ready-for-agent` | `status:ready-for-agent` | Fully specified and ready for Codex implementation. |
+| `ready-for-human` | `status:ready-for-human` | Requires human implementation, product judgment, or live validation. |
+| `wontfix` | `wontfix` | Will not be actioned. |
+
+When a skill mentions a canonical role, apply the corresponding repo label from this table.
+
+The repo also uses type, priority, and area labels. New implementation work should keep using the established pattern:
+
+- `type:*`
+- `priority:*`
+- `area:*`
+- one `status:*` label


### PR DESCRIPTION
## 变更概述\n\n为仓库接入 Aveouter/engneering_skills 的工程管理流程，新增 Codex 可读取的项目级 agent 配置。\n\nCloses #152\n\n## 修改动机\n\n后续使用 to-issues、triage、to-prd、diagnose、tdd、zoom-out 和 improve-codebase-architecture 时，需要明确当前仓库的 issue tracker、triage 标签映射和领域文档布局，避免每次重新推断项目流程。\n\n## 主要改动\n\n- 新增 AGENTS.md，记录 Agent skills 入口配置。\n- 新增 docs/agents/issue-tracker.md，声明 GitHub Issues 为项目 issue tracker。\n- 新增 docs/agents/triage-labels.md，记录已确认的 status:* 标签映射。\n- 新增 docs/agents/domain.md，记录单上下文领域文档布局。\n- 已在 GitHub Labels 中补齐 status:needs-triage、status:needs-info、status:ready-for-agent、status:ready-for-human。\n\n## 实验与验证\n\n- 验证 GitHub Labels 已存在：status:needs-triage、status:needs-info、status:ready-for-agent、status:ready-for-human、wontfix。\n- 本次仅新增流程文档，未运行 Mod 构建或逻辑测试。\n\n## 对 Benchmark / Baseline 的影响\n\n不影响数据集、评测协议、指标定义、Baseline 或结果可复现性。\n\n## 风险与限制\n\n- 本次只配置 engineering skills 的读取入口，不改变游戏功能代码。\n- CONTEXT.md 和 docs/adr/ 当前按需懒创建；本 PR 不预填领域词典或 ADR。